### PR TITLE
Fix cross-language Bible reference search

### DIFF
--- a/js/panel/render-and-selection.js
+++ b/js/panel/render-and-selection.js
@@ -1,2009 +1,2479 @@
-    function updateSearchPlaceholder() {
-      const inp = document.getElementById('song-search');
-      const mirror = document.getElementById('nav-mirror-search');
-      if (!inp) return;
-      if (sidebarTab === 'bible') inp.placeholder = t('ui_search_bible');
-      else if (sidebarTab === 'schedule') inp.placeholder = t('ui_search_setlist');
-      else if (sidebarTab === 'media') inp.placeholder = 'Search media...';
-      else inp.placeholder = t('ui_search_songs');
-      updateBibleSearchToolsVisibility();
-      if (mirror) mirror.placeholder = inp.placeholder;
-      restoreSearchInputForCurrentTab();
+function updateSearchPlaceholder() {
+  const inp = document.getElementById("song-search");
+  const mirror = document.getElementById("nav-mirror-search");
+  if (!inp) return;
+  if (sidebarTab === "bible") inp.placeholder = t("ui_search_bible");
+  else if (sidebarTab === "schedule") inp.placeholder = t("ui_search_setlist");
+  else if (sidebarTab === "media") inp.placeholder = "Search media...";
+  else inp.placeholder = t("ui_search_songs");
+  updateBibleSearchToolsVisibility();
+  if (mirror) mirror.placeholder = inp.placeholder;
+  restoreSearchInputForCurrentTab();
+}
+
+function ensureSelectionFallback() {
+  const isBibleCurrent = !!(currentItem && getIsBibleItem(currentItem));
+  if (
+    sidebarTab === "bible" &&
+    activeBibleVersion &&
+    bibles[activeBibleVersion] &&
+    bibles[activeBibleVersion].length
+  ) {
+    const bibleList = bibles[activeBibleVersion];
+    const hasValidBibleSelection =
+      isBibleCurrent &&
+      currentItem.version === activeBibleVersion &&
+      bibleList.includes(currentItem);
+    if (!hasValidBibleSelection) {
+      const idx = _defaultBibleChapterIndex(activeBibleVersion);
+      selectItem(idx >= 0 ? idx : 0);
     }
+    return;
+  }
+  if (sidebarTab === "songs" && songs.length) {
+    const hasValidSongSelection = !!(
+      currentItem &&
+      !isBibleCurrent &&
+      songs.includes(currentItem)
+    );
+    if (!hasValidSongSelection) selectItem(0);
+    return;
+  }
+  if (sidebarTab === "schedule" && schedule.length) {
+    const hasValidScheduleSelection = !!(
+      currentItem && schedule.includes(currentItem)
+    );
+    if (!hasValidScheduleSelection) selectItem(0);
+  }
+}
 
+// ===== UI RENDER =====
+let _acBooks = [];
+let _acIdx = -1;
+function renderBibleAutocomplete() {
+  let sourceBooks = [];
+  if (activeBibleVersion && bibles[activeBibleVersion]) {
+    sourceBooks = [
+      ...new Set(bibles[activeBibleVersion].map((c) => c.book).filter(Boolean)),
+    ];
+  } else {
+    sourceBooks = [...new Set(Object.values(BIBLE_BOOKS))];
+  }
+  _acBooks = sourceBooks;
+}
 
-    function ensureSelectionFallback() {
-      const isBibleCurrent = !!(currentItem && getIsBibleItem(currentItem));
-      if (sidebarTab === 'bible' && activeBibleVersion && bibles[activeBibleVersion] && bibles[activeBibleVersion].length) {
-        const bibleList = bibles[activeBibleVersion];
-        const hasValidBibleSelection = isBibleCurrent &&
-          currentItem.version === activeBibleVersion &&
-          bibleList.includes(currentItem);
-        if (!hasValidBibleSelection) {
-          const idx = _defaultBibleChapterIndex(activeBibleVersion);
-          selectItem(idx >= 0 ? idx : 0);
-        }
-        return;
+function renderVersionBar() {
+  const bar = document.getElementById("version-bar");
+  if (!bar) return;
+  bar.innerHTML = "";
+  const verKeys = Object.keys(bibles);
+  const mid = Math.ceil(verKeys.length / 2);
+  const rows = [verKeys.slice(0, mid), verKeys.slice(mid)];
+  rows.forEach((rowVers) => {
+    if (!rowVers.length) return;
+    const row = document.createElement("div");
+    row.className = "version-row";
+    rowVers.forEach((ver) => {
+      const i = verKeys.indexOf(ver);
+      const wrapper = document.createElement("div");
+      wrapper.className = `version-wrapper ${activeBibleVersion === ver ? "active" : ""}`;
+      const color = VERSION_COLORS[i % VERSION_COLORS.length];
+      if (activeBibleVersion !== ver) {
+        wrapper.style.borderLeftColor = color;
+        wrapper.style.borderLeftWidth = "2px";
       }
-      if (sidebarTab === 'songs' && songs.length) {
-        const hasValidSongSelection = !!(currentItem && !isBibleCurrent && songs.includes(currentItem));
-        if (!hasValidSongSelection) selectItem(0);
-        return;
-      }
-      if (sidebarTab === 'schedule' && schedule.length) {
-        const hasValidScheduleSelection = !!(currentItem && schedule.includes(currentItem));
-        if (!hasValidScheduleSelection) selectItem(0);
-      }
-    }
-    
-    // ===== UI RENDER =====
-    let _acBooks = [];
-    let _acIdx = -1;
-    function renderBibleAutocomplete() {
-      let sourceBooks = [];
-      if (activeBibleVersion && bibles[activeBibleVersion]) {
-        sourceBooks = [...new Set(bibles[activeBibleVersion].map(c => c.book).filter(Boolean))];
-      } else {
-        sourceBooks = [...new Set(Object.values(BIBLE_BOOKS))];
-      }
-      _acBooks = sourceBooks;
-    }
-
-
-    function renderVersionBar() {
-      const bar = document.getElementById('version-bar');
-      if (!bar) return;
-      bar.innerHTML = '';
-      const verKeys = Object.keys(bibles);
-      const mid = Math.ceil(verKeys.length / 2);
-      const rows = [verKeys.slice(0, mid), verKeys.slice(mid)];
-      rows.forEach(rowVers => {
-        if (!rowVers.length) return;
-        const row = document.createElement('div');
-        row.className = 'version-row';
-        rowVers.forEach(ver => {
-          const i = verKeys.indexOf(ver);
-          const wrapper = document.createElement('div');
-          wrapper.className = `version-wrapper ${activeBibleVersion === ver ? 'active' : ''}`;
-          const color = VERSION_COLORS[i % VERSION_COLORS.length];
-          if (activeBibleVersion !== ver) {
-            wrapper.style.borderLeftColor = color;
-            wrapper.style.borderLeftWidth = '2px';
-          }
-          const btn = document.createElement('button');
-          btn.className = 'version-btn';
-          btn.innerText = ver;
-          btn.onclick = () => changeActiveBibleVersion(ver);
-          const del = document.createElement('button');
-          del.className = 'version-del';
-          del.innerText = '\u2715';
-          del.onclick = (e) => {
-            e.stopPropagation();
-            delete bibles[ver];
-            clearBibleSearchCache(ver);
-            if (activeBibleVersion === ver) activeBibleVersion = null;
-            idbDelete(STORE_BIBLES, ver).catch(() => {});
-            saveState();
-            saveToStorageDebounced();
-            renderVersionBar();
-            renderSongs();
-            updateBibleLists();
-            if (isLive) scheduleLiveUpdate();
-          };
-          wrapper.appendChild(btn);
-          wrapper.appendChild(del);
-          row.appendChild(wrapper);
-        });
-        bar.appendChild(row);
-      });
-      updateBibleLists();
-      updateDualVersionSelects();
-      updateDualVersionAvailability();
-      renderFooterBibleVersionPopover();
-      if (footerBibleVersionPopoverOpen) {
-        requestAnimationFrame(positionFooterBibleVersionPopover);
-      }
-    }
-
-    function extractBookAndChapter(item) {
-      if (!item) return { book: null, chap: null };
-      const book = item.book || null;
-      const chap = item.chapter || null;
-      if (book && chap) return { book, chap };
-      const title = item.title || "";
-      const parts = title.split(' ');
-      if (parts.length < 2) return { book: null, chap: null };
-      const last = parts.pop();
-      if (!/^\d+$/.test(last)) return { book: title, chap: null };
-      return { book: parts.join(' '), chap: last };
-    }
-
-    const bibleBookOrderCache = new Map();
-
-    function normalizeBookName(name) {
-      return normalizeSearchText(name).replace(/\s+/g, ' ').trim();
-    }
-
-    function getBibleBookOrder(version) {
-      const list = (version && bibles[version]) ? bibles[version] : [];
-      const firstTitle = list[0]?.title || '';
-      const lastTitle = list[list.length - 1]?.title || '';
-      const cacheKey = `${version || ''}|${list.length}|${firstTitle}|${lastTitle}`;
-      const cached = bibleBookOrderCache.get(version);
-      if (cached && cached.key === cacheKey) return cached.order;
-      const seen = new Set();
-      const order = [];
-      list.forEach(item => {
-        const book = item?.book || extractBookAndChapter(item).book;
-        const key = normalizeBookName(book);
-        if (!key || seen.has(key)) return;
-        seen.add(key);
-        order.push(book);
-      });
-      bibleBookOrderCache.set(version, { key: cacheKey, order });
-      return order;
-    }
-
-    function findBibleChapterIndex(version, bookName, chap, fallbackIndex) {
-      const list = (version && bibles[version]) ? bibles[version] : [];
-      if (!list.length) return -1;
-      const chapStr = (chap == null) ? null : String(chap);
-      const bookKey = normalizeBookName(bookName);
-      let idx = -1;
-
-      if (bookKey && chapStr) {
-        idx = list.findIndex(item => {
-          const itemBook = normalizeBookName(item?.book || extractBookAndChapter(item).book);
-          const itemChap = String(item?.chapter || extractBookAndChapter(item).chap || "");
-          return itemBook === bookKey && itemChap === chapStr;
-        });
-      }
-
-      if (idx === -1 && typeof fallbackIndex === 'number' && fallbackIndex >= 0 && fallbackIndex < list.length) {
-        idx = fallbackIndex;
-      }
-      return idx;
-    }
-
-    function changeActiveBibleVersion(ver) {
-      const previousPrimary = activeBibleVersion;
-      let targetVerse = null;
-      let targetLineCursor = lineCursor;
-      let targetBook = null;
-      let targetChap = null;
-      let targetBookIndex = null;
-
-      if (sidebarTab === 'bible' && currentItem) {
-        const currentPages = getPagesFromItem(currentItem, true);
-        const curPage = currentPages[lineCursor];
-        if (curPage && curPage.raw) {
-          const firstLine = (curPage.raw.split('\n').find(l => l.trim()) || '').trim();
-          const matchVerse = firstLine.match(/^(\d+)/);
-          if (matchVerse) targetVerse = matchVerse[1];
-        }
-        const extracted = extractBookAndChapter(currentItem);
-        targetBook = extracted.book;
-        targetChap = extracted.chap;
-        if (targetBook && activeBibleVersion) {
-          const order = getBibleBookOrder(activeBibleVersion);
-          const foundIdx = order.findIndex(name => normalizeBookName(name) === normalizeBookName(targetBook));
-          if (foundIdx !== -1) targetBookIndex = foundIdx;
-        }
-      }
-
-      if (activeBibleVersion === ver) {
-        activeBibleVersion = null;
+      const btn = document.createElement("button");
+      btn.className = "version-btn";
+      btn.innerText = ver;
+      btn.onclick = () => changeActiveBibleVersion(ver);
+      const del = document.createElement("button");
+      del.className = "version-del";
+      del.innerText = "\u2715";
+      del.onclick = (e) => {
+        e.stopPropagation();
+        delete bibles[ver];
+        clearBibleSearchCache(ver);
+        if (activeBibleVersion === ver) activeBibleVersion = null;
+        idbDelete(STORE_BIBLES, ver).catch(() => {});
+        saveState();
+        saveToStorageDebounced();
         renderVersionBar();
         renderSongs();
         updateBibleLists();
-        return;
-      }
-      activeBibleVersion = ver;
-      if (dualVersionModeEnabled && dualVersionSecondaryId && activeBibleVersion && dualVersionSecondaryId === activeBibleVersion) {
-        const fallbackSecondary = (previousPrimary && previousPrimary !== activeBibleVersion) ? previousPrimary : null;
-        setDualVersionSecondaryId(fallbackSecondary, { silent: true });
-      }
-      renderVersionBar();
-      updateBibleLists();
-      if (sidebarTab === 'bible') {
-        if (bibles[activeBibleVersion]) {
-          const order = getBibleBookOrder(activeBibleVersion);
-          const resolvedBook = (targetBookIndex != null && order[targetBookIndex]) ? order[targetBookIndex] : targetBook;
-          const idx = findBibleChapterIndex(activeBibleVersion, resolvedBook, targetChap, currentIndex);
-          if (idx !== -1) {
-            selectItem(idx, { preserveLineCursor: true, skipButtonView: true });
-            const newItem = bibles[activeBibleVersion][idx];
-            const newPages = getPagesFromItem(newItem, true);
-            let nextLineCursor = Math.min(targetLineCursor, Math.max(0, newPages.length - 1));
-            if (targetVerse) {
-              const foundIdx = newPages.findIndex(p => (p.raw || '').split('\n').some(line => line.trim().startsWith(`${targetVerse} `)));
-              if (foundIdx !== -1) nextLineCursor = foundIdx;
-            }
-            if (lineCursor !== nextLineCursor) {
-              lineCursor = nextLineCursor;
-            }
-            updateButtonView({ preserveScroll: true, skipAutoScroll: true });
-            if (versionSwitchUpdatesLive && isLive && livePointer && livePointer.kind === 'bible') {
-              livePointer = { kind: 'bible', version: activeBibleVersion, index: idx };
-              liveLineCursor = lineCursor;
-              pushLiveUpdate();
-            }
-            saveToStorageDebounced();
-            return;
-          }
-        }
-        ensureSelectionFallback();
-      } else {
-        renderSongs();
-      }
-      saveToStorageDebounced();
-    }
+        if (isLive) scheduleLiveUpdate();
+      };
+      wrapper.appendChild(btn);
+      wrapper.appendChild(del);
+      row.appendChild(wrapper);
+    });
+    bar.appendChild(row);
+  });
+  updateBibleLists();
+  updateDualVersionSelects();
+  updateDualVersionAvailability();
+  renderFooterBibleVersionPopover();
+  if (footerBibleVersionPopoverOpen) {
+    requestAnimationFrame(positionFooterBibleVersionPopover);
+  }
+}
 
-    function updateBibleLists() {
-      const bookSelect = document.getElementById('bible-book-select');
-      const chapSelect = document.getElementById('bible-chap-select');
-      
-      if (!bookSelect || !chapSelect) return;
-      
-      bookSelect.innerHTML = `<option value="">${esc(t('ui_select_book'))}</option>`;
-      chapSelect.innerHTML = `<option value="">${esc(t('ui_chapter_short'))}</option>`;
-      chapSelect.disabled = true;
-      
-      if (!activeBibleVersion || !bibles[activeBibleVersion]) return;
-      
-      const uniqueBooks = [...new Set(bibles[activeBibleVersion].map(c => {
-        const parts = c.title.split(' ');
-        return parts.slice(0, -1).join(' ');
-      }))];
-      
-      uniqueBooks.forEach(book => {
-        const opt = document.createElement('option');
-        opt.value = book;
-        opt.textContent = book;
-        bookSelect.appendChild(opt);
-      });
-    }
+function extractBookAndChapter(item) {
+  if (!item) return { book: null, chap: null };
+  const book = item.book || null;
+  const chap = item.chapter || null;
+  if (book && chap) return { book, chap };
+  const title = item.title || "";
+  const parts = title.split(" ");
+  if (parts.length < 2) return { book: null, chap: null };
+  const last = parts.pop();
+  if (!/^\d+$/.test(last)) return { book: title, chap: null };
+  return { book: parts.join(" "), chap: last };
+}
 
-    function resetBibleDropdowns() {
-      const bookSelect = document.getElementById('bible-book-select');
-      const chapSelect = document.getElementById('bible-chap-select');
-      if (bookSelect) {
-        bookSelect.value = '';
-      }
-      if (chapSelect) {
-        chapSelect.innerHTML = `<option value="">${esc(t('ui_chapter_short'))}</option>`;
-        chapSelect.disabled = true;
-      }
-    }
+const bibleBookOrderCache = new Map();
 
-    function handleBookSelect() {
-      const bookSelect = document.getElementById('bible-book-select');
-      const chapSelect = document.getElementById('bible-chap-select');
-      const book = bookSelect.value;
-      
-      chapSelect.innerHTML = `<option value="">${esc(t('ui_chapter_short'))}</option>`;
-      
-      if (!book || !activeBibleVersion || !bibles[activeBibleVersion]) {
-        chapSelect.disabled = true;
-        return;
-      }
-      
-      chapSelect.disabled = false;
-      
-      const chapters = bibles[activeBibleVersion]
-        .filter(c => {
-          const bookPart = c.title.split(' ').slice(0, -1).join(' ');
-          return bookPart === book;
-        })
-        .map(c => c.title.split(' ').pop());
-      
-      const uniqueChaps = [...new Set(chapters)].sort((a, b) => parseInt(a) - parseInt(b));
-      uniqueChaps.forEach(chap => {
-        const opt = document.createElement('option');
-        opt.value = chap;
-        opt.textContent = chap;
-        chapSelect.appendChild(opt);
-      });
-      renderBibleAutocomplete();
-      renderSongs();
-    }
+function normalizeBookName(name) {
+  return normalizeSearchText(name).replace(/\s+/g, " ").trim();
+}
 
-    function handleChapterSelect() {
-      const bookSelect = document.getElementById('bible-book-select');
-      const chapSelect = document.getElementById('bible-chap-select');
-      const book = bookSelect.value;
-      const chap = chapSelect.value;
-      
-      if (!book || !chap || !activeBibleVersion || !bibles[activeBibleVersion]) return;
-      
-      const idx = bibles[activeBibleVersion].findIndex(c => {
-        const bookPart = c.title.split(' ').slice(0, -1).join(' ');
-        const chapPart = c.title.split(' ').pop();
-        return bookPart === book && chapPart === chap;
-      });
-      
-      if (idx !== -1) selectItem(idx);
+function getBibleBookOrder(version) {
+  const list = version && bibles[version] ? bibles[version] : [];
+  const firstTitle = list[0]?.title || "";
+  const lastTitle = list[list.length - 1]?.title || "";
+  const cacheKey = `${version || ""}|${list.length}|${firstTitle}|${lastTitle}`;
+  const cached = bibleBookOrderCache.get(version);
+  if (cached && cached.key === cacheKey) return cached.order;
+  const seen = new Set();
+  const order = [];
+  list.forEach((item) => {
+    const book = item?.book || extractBookAndChapter(item).book;
+    const key = normalizeBookName(book);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    order.push(book);
+  });
+  bibleBookOrderCache.set(version, { key: cacheKey, order });
+  return order;
+}
+
+function findBibleChapterIndex(version, bookName, chap, fallbackIndex) {
+  const list = version && bibles[version] ? bibles[version] : [];
+  if (!list.length) return -1;
+  const chapStr = chap == null ? null : String(chap);
+  const bookKey = normalizeBookName(bookName);
+  let idx = -1;
+
+  if (bookKey && chapStr) {
+    idx = list.findIndex((item) => {
+      const itemBook = normalizeBookName(
+        item?.book || extractBookAndChapter(item).book,
+      );
+      const itemChap = String(
+        item?.chapter || extractBookAndChapter(item).chap || "",
+      );
+      return itemBook === bookKey && itemChap === chapStr;
+    });
+  }
+
+  if (
+    idx === -1 &&
+    typeof fallbackIndex === "number" &&
+    fallbackIndex >= 0 &&
+    fallbackIndex < list.length
+  ) {
+    idx = fallbackIndex;
+  }
+  return idx;
+}
+
+function changeActiveBibleVersion(ver) {
+  const previousPrimary = activeBibleVersion;
+  let targetVerse = null;
+  let targetLineCursor = lineCursor;
+  let targetBook = null;
+  let targetChap = null;
+  let targetBookIndex = null;
+
+  if (sidebarTab === "bible" && currentItem) {
+    const currentPages = getPagesFromItem(currentItem, true);
+    const curPage = currentPages[lineCursor];
+    if (curPage && curPage.raw) {
+      const firstLine = (
+        curPage.raw.split("\n").find((l) => l.trim()) || ""
+      ).trim();
+      const matchVerse = firstLine.match(/^(\d+)/);
+      if (matchVerse) targetVerse = matchVerse[1];
+    }
+    const extracted = extractBookAndChapter(currentItem);
+    targetBook = extracted.book;
+    targetChap = extracted.chap;
+    if (targetBook && activeBibleVersion) {
+      const order = getBibleBookOrder(activeBibleVersion);
+      const foundIdx = order.findIndex(
+        (name) => normalizeBookName(name) === normalizeBookName(targetBook),
+      );
+      if (foundIdx !== -1) targetBookIndex = foundIdx;
+    }
+  }
+
+  if (activeBibleVersion === ver) {
+    activeBibleVersion = null;
+    renderVersionBar();
+    renderSongs();
+    updateBibleLists();
+    return;
+  }
+  activeBibleVersion = ver;
+  if (
+    dualVersionModeEnabled &&
+    dualVersionSecondaryId &&
+    activeBibleVersion &&
+    dualVersionSecondaryId === activeBibleVersion
+  ) {
+    const fallbackSecondary =
+      previousPrimary && previousPrimary !== activeBibleVersion
+        ? previousPrimary
+        : null;
+    setDualVersionSecondaryId(fallbackSecondary, { silent: true });
+  }
+  renderVersionBar();
+  updateBibleLists();
+  if (sidebarTab === "bible") {
+    if (bibles[activeBibleVersion]) {
+      const order = getBibleBookOrder(activeBibleVersion);
+      const resolvedBook =
+        targetBookIndex != null && order[targetBookIndex]
+          ? order[targetBookIndex]
+          : targetBook;
+      const idx = findBibleChapterIndex(
+        activeBibleVersion,
+        resolvedBook,
+        targetChap,
+        currentIndex,
+      );
       if (idx !== -1) {
-        const picked = bibles[activeBibleVersion][idx];
-        const extracted = extractBookAndChapter(picked);
-        addBibleRecentReference(buildBibleRefEntry(extracted.book, extracted.chap, null, null, activeBibleVersion));
-      }
-    }
-
-    let dragIndex = null;
-
-    function renderBibleSearchResults(qRaw) {
-      const list = document.getElementById('song-list');
-      const normalizedQuery = normalizeSearchText(qRaw || '').trim();
-      if (normalizedQuery !== lastBibleSearchQuery) currentSearchPos = null;
-      lastBibleSearchQuery = normalizedQuery;
-      list.innerHTML = '';
-      if (!activeBibleVersion && Object.keys(bibles).length > 0) {
-        activeBibleVersion = Object.keys(bibles)[0];
-        renderVersionBar();
-      }
-      if (!activeBibleVersion || !bibles[activeBibleVersion]) return;
-      const selectedBook = document.getElementById('bible-book-select')?.value || '';
-      const referenceQuery = parseBibleReferenceQuery(qRaw);
-      const results = referenceQuery
-        ? findBibleReferenceMatches(referenceQuery, {
-            versionId: activeBibleVersion,
-            book: selectedBook
-          })
-        : findBibleKeywordMatches(qRaw, {
-            versionId: activeBibleVersion,
-            book: selectedBook,
-            maxResults: 200
-          });
-      if (currentSearchPos != null && (currentSearchPos < 0 || currentSearchPos >= results.length)) {
-        currentSearchPos = null;
-      }
-      if (!results.length) {
-        const empty = document.createElement('div');
-        empty.className = 'song-item';
-        empty.style.cursor = 'default';
-        empty.style.opacity = '0.7';
-        empty.innerText = 'No matches found';
-        list.appendChild(empty);
-        list._navMirrorItems = [];
+        selectItem(idx, { preserveLineCursor: true, skipButtonView: true });
+        const newItem = bibles[activeBibleVersion][idx];
+        const newPages = getPagesFromItem(newItem, true);
+        let nextLineCursor = Math.min(
+          targetLineCursor,
+          Math.max(0, newPages.length - 1),
+        );
+        if (targetVerse) {
+          const foundIdx = newPages.findIndex((p) =>
+            (p.raw || "")
+              .split("\n")
+              .some((line) => line.trim().startsWith(`${targetVerse} `)),
+          );
+          if (foundIdx !== -1) nextLineCursor = foundIdx;
+        }
+        if (lineCursor !== nextLineCursor) {
+          lineCursor = nextLineCursor;
+        }
+        updateButtonView({ preserveScroll: true, skipAutoScroll: true });
+        if (
+          versionSwitchUpdatesLive &&
+          isLive &&
+          livePointer &&
+          livePointer.kind === "bible"
+        ) {
+          livePointer = {
+            kind: "bible",
+            version: activeBibleVersion,
+            index: idx,
+          };
+          liveLineCursor = lineCursor;
+          pushLiveUpdate();
+        }
+        saveToStorageDebounced();
         return;
       }
-      const bibleList = (activeBibleVersion && bibles[activeBibleVersion]) ? bibles[activeBibleVersion] : [];
-      list._navMirrorItems = results.map((entry, resultIndex) => {
-        const sourceItem = bibleList[entry.chapterIndex] || null;
-        return {
-          title: `${entry.book} ${entry.chapter}:${entry.verse}`,
-          snippet: entry.text || '',
-          active: currentSearchPos === resultIndex,
-          activate: () => {
-            currentSearchPos = resultIndex;
-            activateBibleSearchResult(entry.chapterIndex, entry.verse);
-          },
-          contextMenu: (clientX, clientY) => {
-            if (typeof window._openSidebarContextMenu !== 'function' || !sourceItem) return;
-            window._openSidebarContextMenu('bible', sourceItem, entry.chapterIndex, resultIndex, clientX, clientY, { bibleVerse: entry.verse });
-          }
-        };
+    }
+    ensureSelectionFallback();
+  } else {
+    renderSongs();
+  }
+  saveToStorageDebounced();
+}
+
+function updateBibleLists() {
+  const bookSelect = document.getElementById("bible-book-select");
+  const chapSelect = document.getElementById("bible-chap-select");
+
+  if (!bookSelect || !chapSelect) return;
+
+  bookSelect.innerHTML = `<option value="">${esc(t("ui_select_book"))}</option>`;
+  chapSelect.innerHTML = `<option value="">${esc(t("ui_chapter_short"))}</option>`;
+  chapSelect.disabled = true;
+
+  if (!activeBibleVersion || !bibles[activeBibleVersion]) return;
+
+  const uniqueBooks = [
+    ...new Set(
+      bibles[activeBibleVersion].map((c) => {
+        const parts = c.title.split(" ");
+        return parts.slice(0, -1).join(" ");
+      }),
+    ),
+  ];
+
+  uniqueBooks.forEach((book) => {
+    const opt = document.createElement("option");
+    opt.value = book;
+    opt.textContent = book;
+    bookSelect.appendChild(opt);
+  });
+}
+
+function resetBibleDropdowns() {
+  const bookSelect = document.getElementById("bible-book-select");
+  const chapSelect = document.getElementById("bible-chap-select");
+  if (bookSelect) {
+    bookSelect.value = "";
+  }
+  if (chapSelect) {
+    chapSelect.innerHTML = `<option value="">${esc(t("ui_chapter_short"))}</option>`;
+    chapSelect.disabled = true;
+  }
+}
+
+function handleBookSelect() {
+  const bookSelect = document.getElementById("bible-book-select");
+  const chapSelect = document.getElementById("bible-chap-select");
+  const book = bookSelect.value;
+
+  chapSelect.innerHTML = `<option value="">${esc(t("ui_chapter_short"))}</option>`;
+
+  if (!book || !activeBibleVersion || !bibles[activeBibleVersion]) {
+    chapSelect.disabled = true;
+    return;
+  }
+
+  chapSelect.disabled = false;
+
+  const chapters = bibles[activeBibleVersion]
+    .filter((c) => {
+      const bookPart = c.title.split(" ").slice(0, -1).join(" ");
+      return bookPart === book;
+    })
+    .map((c) => c.title.split(" ").pop());
+
+  const uniqueChaps = [...new Set(chapters)].sort(
+    (a, b) => parseInt(a) - parseInt(b),
+  );
+  uniqueChaps.forEach((chap) => {
+    const opt = document.createElement("option");
+    opt.value = chap;
+    opt.textContent = chap;
+    chapSelect.appendChild(opt);
+  });
+  renderBibleAutocomplete();
+  renderSongs();
+}
+
+function handleChapterSelect() {
+  const bookSelect = document.getElementById("bible-book-select");
+  const chapSelect = document.getElementById("bible-chap-select");
+  const book = bookSelect.value;
+  const chap = chapSelect.value;
+
+  if (!book || !chap || !activeBibleVersion || !bibles[activeBibleVersion])
+    return;
+
+  const idx = bibles[activeBibleVersion].findIndex((c) => {
+    const bookPart = c.title.split(" ").slice(0, -1).join(" ");
+    const chapPart = c.title.split(" ").pop();
+    return bookPart === book && chapPart === chap;
+  });
+
+  if (idx !== -1) selectItem(idx);
+  if (idx !== -1) {
+    const picked = bibles[activeBibleVersion][idx];
+    const extracted = extractBookAndChapter(picked);
+    addBibleRecentReference(
+      buildBibleRefEntry(
+        extracted.book,
+        extracted.chap,
+        null,
+        null,
+        activeBibleVersion,
+      ),
+    );
+  }
+}
+
+let dragIndex = null;
+
+function renderBibleSearchResults(qRaw) {
+  const list = document.getElementById("song-list");
+  const normalizedQuery = normalizeSearchText(qRaw || "").trim();
+  if (normalizedQuery !== lastBibleSearchQuery) currentSearchPos = null;
+  lastBibleSearchQuery = normalizedQuery;
+  list.innerHTML = "";
+  if (!activeBibleVersion && Object.keys(bibles).length > 0) {
+    activeBibleVersion = Object.keys(bibles)[0];
+    renderVersionBar();
+  }
+  if (!activeBibleVersion || !bibles[activeBibleVersion]) return;
+  const selectedBook =
+    document.getElementById("bible-book-select")?.value || "";
+  const referenceQuery = parseBibleReferenceQuery(qRaw);
+  const results = referenceQuery
+    ? findBibleReferenceMatches(referenceQuery, {
+        versionId: activeBibleVersion,
+        book: selectedBook,
+      })
+    : findBibleKeywordMatches(qRaw, {
+        versionId: activeBibleVersion,
+        book: selectedBook,
+        maxResults: 200,
       });
-      results.forEach((entry, resultIndex) => {
-        const div = document.createElement('div');
-        div.className = 'song-item';
-        if (currentSearchPos === resultIndex) div.classList.add('active');
-        div.dataset.index = String(entry.chapterIndex);
-        div.dataset.chapterIndex = String(entry.chapterIndex);
-        div.dataset.verse = String(entry.verse);
-        div.dataset.pos = String(resultIndex);
-        const left = document.createElement('div');
-        const title = document.createElement('span');
-        title.className = 'search-title';
-        title.textContent = `${entry.book} ${entry.chapter}:${entry.verse}`;
-        const snippet = document.createElement('span');
-        snippet.className = 'search-snippet';
-        snippet.textContent = entry.text;
-        left.appendChild(title);
-        left.appendChild(snippet);
-        div.appendChild(left);
-        div.onclick = () => {
-          currentSearchPos = resultIndex;
-          activateBibleSearchResult(entry.chapterIndex, entry.verse);
-        };
-        div.ondblclick = () => {
-          currentSearchPos = resultIndex;
-          activateBibleSearchResult(entry.chapterIndex, entry.verse);
-          projectLive(true);
-        };
-        div.addEventListener('contextmenu', (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          if (typeof window._openSidebarContextMenu !== 'function') return;
-          const bibleList = (activeBibleVersion && bibles[activeBibleVersion]) ? bibles[activeBibleVersion] : [];
-          const sourceItem = bibleList[entry.chapterIndex];
-          if (!sourceItem) return;
-          window._openSidebarContextMenu(
-            'bible',
-            sourceItem,
-            entry.chapterIndex,
-            resultIndex,
-            e.clientX,
-            e.clientY,
-            { bibleVerse: entry.verse }
-          );
-        });
-        list.appendChild(div);
-      });
-    }
+  if (
+    currentSearchPos != null &&
+    (currentSearchPos < 0 || currentSearchPos >= results.length)
+  ) {
+    currentSearchPos = null;
+  }
+  if (!results.length) {
+    const empty = document.createElement("div");
+    empty.className = "song-item";
+    empty.style.cursor = "default";
+    empty.style.opacity = "0.7";
+    empty.innerText = "No matches found";
+    list.appendChild(empty);
+    list._navMirrorItems = [];
+    return;
+  }
+  const bibleList =
+    activeBibleVersion && bibles[activeBibleVersion]
+      ? bibles[activeBibleVersion]
+      : [];
+  list._navMirrorItems = results.map((entry, resultIndex) => {
+    const sourceItem = bibleList[entry.chapterIndex] || null;
+    return {
+      title: `${entry.book} ${entry.chapter}:${entry.verse}`,
+      snippet: entry.text || "",
+      active: currentSearchPos === resultIndex,
+      activate: () => {
+        currentSearchPos = resultIndex;
+        activateBibleSearchResult(entry.chapterIndex, entry.verse);
+      },
+      contextMenu: (clientX, clientY) => {
+        if (typeof window._openSidebarContextMenu !== "function" || !sourceItem)
+          return;
+        window._openSidebarContextMenu(
+          "bible",
+          sourceItem,
+          entry.chapterIndex,
+          resultIndex,
+          clientX,
+          clientY,
+          { bibleVerse: entry.verse },
+        );
+      },
+    };
+  });
+  results.forEach((entry, resultIndex) => {
+    const div = document.createElement("div");
+    div.className = "song-item";
+    if (currentSearchPos === resultIndex) div.classList.add("active");
+    div.dataset.index = String(entry.chapterIndex);
+    div.dataset.chapterIndex = String(entry.chapterIndex);
+    div.dataset.verse = String(entry.verse);
+    div.dataset.pos = String(resultIndex);
+    const left = document.createElement("div");
+    const title = document.createElement("span");
+    title.className = "search-title";
+    title.textContent = `${entry.book} ${entry.chapter}:${entry.verse}`;
+    const snippet = document.createElement("span");
+    snippet.className = "search-snippet";
+    snippet.textContent = entry.text;
+    left.appendChild(title);
+    left.appendChild(snippet);
+    div.appendChild(left);
+    div.onclick = () => {
+      currentSearchPos = resultIndex;
+      activateBibleSearchResult(entry.chapterIndex, entry.verse);
+    };
+    div.ondblclick = () => {
+      currentSearchPos = resultIndex;
+      activateBibleSearchResult(entry.chapterIndex, entry.verse);
+      projectLive(true);
+    };
+    div.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (typeof window._openSidebarContextMenu !== "function") return;
+      const bibleList =
+        activeBibleVersion && bibles[activeBibleVersion]
+          ? bibles[activeBibleVersion]
+          : [];
+      const sourceItem = bibleList[entry.chapterIndex];
+      if (!sourceItem) return;
+      window._openSidebarContextMenu(
+        "bible",
+        sourceItem,
+        entry.chapterIndex,
+        resultIndex,
+        e.clientX,
+        e.clientY,
+        { bibleVerse: entry.verse },
+      );
+    });
+    list.appendChild(div);
+  });
+}
 
-    function activateBibleSearchResult(chapterIndex, verse) {
-      selectItem(chapterIndex, { preserveLineCursor: true, skipButtonView: true });
-      setBibleGroupAnchor(verse, currentItem);
-      const pages = getPagesFromItem(currentItem, true);
-      const vIdx = pages.findIndex(p => matchesVerseStart(p.raw, verse));
-      if (vIdx !== -1) lineCursor = vIdx;
-      updateButtonView();
-      if (currentItem) {
-        const extracted = extractBookAndChapter(currentItem);
-        addBibleRecentReference(buildBibleRefEntry(extracted.book, extracted.chap, verse, null, activeBibleVersion));
-      }
-    }
+function activateBibleSearchResult(chapterIndex, verse) {
+  selectItem(chapterIndex, { preserveLineCursor: true, skipButtonView: true });
+  setBibleGroupAnchor(verse, currentItem);
+  const pages = getPagesFromItem(currentItem, true);
+  const vIdx = pages.findIndex((p) => matchesVerseStart(p.raw, verse));
+  if (vIdx !== -1) lineCursor = vIdx;
+  updateButtonView();
+  if (currentItem) {
+    const extracted = extractBookAndChapter(currentItem);
+    addBibleRecentReference(
+      buildBibleRefEntry(
+        extracted.book,
+        extracted.chap,
+        verse,
+        null,
+        activeBibleVersion,
+      ),
+    );
+  }
+}
 
-    function navigateSidebar(delta) {
-      const list = document.getElementById('song-list');
-      if (!list) return;
-      const items = Array.from(list.querySelectorAll('.song-item'));
-      if (!items.length) return;
-      const usePos = items.some(item => item.dataset.pos != null);
-      let currentIdx = -1;
-      if (usePos && currentSearchPos != null) {
-        currentIdx = items.findIndex(item => item.dataset.pos === String(currentSearchPos));
-      } else if (currentItem && currentIndex != null) {
-        currentIdx = items.findIndex(item => Number(item.dataset.index) === currentIndex);
-      }
-      if (currentIdx === -1) {
-        const activeEl = list.querySelector('.song-item.active');
-        if (activeEl) currentIdx = items.indexOf(activeEl);
-      }
-      let nextIdx = (currentIdx === -1) ? (delta > 0 ? 0 : items.length - 1) : currentIdx + delta;
-      nextIdx = Math.max(0, Math.min(items.length - 1, nextIdx));
-      const target = items[nextIdx];
-      if (!target) return;
-      const idx = Number(target.dataset.index);
-      if (!Number.isFinite(idx)) return;
-      if (usePos) {
-        const pos = Number(target.dataset.pos);
-        if (Number.isFinite(pos)) currentSearchPos = pos;
-        const verse = Number(target.dataset.verse);
-        if (Number.isFinite(verse)) {
-          activateBibleSearchResult(idx, verse);
-        } else {
-          selectItem(idx);
-        }
-      } else {
-        currentSearchPos = null;
-        selectItem(idx);
-      }
-      requestAnimationFrame(() => {
-        ensureSidebarItemVisible(idx, usePos ? currentSearchPos : null);
-      });
+function navigateSidebar(delta) {
+  const list = document.getElementById("song-list");
+  if (!list) return;
+  const items = Array.from(list.querySelectorAll(".song-item"));
+  if (!items.length) return;
+  const usePos = items.some((item) => item.dataset.pos != null);
+  let currentIdx = -1;
+  if (usePos && currentSearchPos != null) {
+    currentIdx = items.findIndex(
+      (item) => item.dataset.pos === String(currentSearchPos),
+    );
+  } else if (currentItem && currentIndex != null) {
+    currentIdx = items.findIndex(
+      (item) => Number(item.dataset.index) === currentIndex,
+    );
+  }
+  if (currentIdx === -1) {
+    const activeEl = list.querySelector(".song-item.active");
+    if (activeEl) currentIdx = items.indexOf(activeEl);
+  }
+  let nextIdx =
+    currentIdx === -1 ? (delta > 0 ? 0 : items.length - 1) : currentIdx + delta;
+  nextIdx = Math.max(0, Math.min(items.length - 1, nextIdx));
+  const target = items[nextIdx];
+  if (!target) return;
+  const idx = Number(target.dataset.index);
+  if (!Number.isFinite(idx)) return;
+  if (usePos) {
+    const pos = Number(target.dataset.pos);
+    if (Number.isFinite(pos)) currentSearchPos = pos;
+    const verse = Number(target.dataset.verse);
+    if (Number.isFinite(verse)) {
+      activateBibleSearchResult(idx, verse);
+    } else {
+      selectItem(idx);
     }
+  } else {
+    currentSearchPos = null;
+    selectItem(idx);
+  }
+  requestAnimationFrame(() => {
+    ensureSidebarItemVisible(idx, usePos ? currentSearchPos : null);
+  });
+}
 
-    function ensureSidebarItemVisible(idx, pos = null) {
-      const list = document.getElementById('song-list');
-      if (!list || list.clientHeight === 0) return;
-      let item = null;
-      if (pos != null) item = list.querySelector(`.song-item[data-pos="${pos}"]`);
-      if (!item) item = list.querySelector(`.song-item[data-index="${idx}"]`);
-      if (!item) return;
-      const listRect = list.getBoundingClientRect();
-      const itemRect = item.getBoundingClientRect();
-      const pad = 6;
-      const topDelta = itemRect.top - (listRect.top + pad);
-      const bottomDelta = itemRect.bottom - (listRect.bottom - pad);
-      if (topDelta < 0) list.scrollTop += topDelta;
-      else if (bottomDelta > 0) list.scrollTop += bottomDelta;
-    }
+function ensureSidebarItemVisible(idx, pos = null) {
+  const list = document.getElementById("song-list");
+  if (!list || list.clientHeight === 0) return;
+  let item = null;
+  if (pos != null) item = list.querySelector(`.song-item[data-pos="${pos}"]`);
+  if (!item) item = list.querySelector(`.song-item[data-index="${idx}"]`);
+  if (!item) return;
+  const listRect = list.getBoundingClientRect();
+  const itemRect = item.getBoundingClientRect();
+  const pad = 6;
+  const topDelta = itemRect.top - (listRect.top + pad);
+  const bottomDelta = itemRect.bottom - (listRect.bottom - pad);
+  if (topDelta < 0) list.scrollTop += topDelta;
+  else if (bottomDelta > 0) list.scrollTop += bottomDelta;
+}
 
-    /* ══════════════════════════════════════════════
+/* ══════════════════════════════════════════════
        Sidebar Context Menu (Song / Bible / Setlist)
        ══════════════════════════════════════════════ */
-    (function _initSidebarContextMenu() {
-      const menu = document.getElementById('sidebar-context-menu');
-      if (!menu) return;
-      if (menu.parentElement !== document.body) document.body.appendChild(menu);
+(function _initSidebarContextMenu() {
+  const menu = document.getElementById("sidebar-context-menu");
+  if (!menu) return;
+  if (menu.parentElement !== document.body) document.body.appendChild(menu);
 
-      function close() {
-        menu.classList.remove('open');
-        menu.setAttribute('aria-hidden', 'true');
-        menu.innerHTML = '';
-      }
+  function close() {
+    menu.classList.remove("open");
+    menu.setAttribute("aria-hidden", "true");
+    menu.innerHTML = "";
+  }
 
-      document.addEventListener('mousedown', (e) => {
-        if (!menu.classList.contains('open')) return;
-        const t = e.target && e.target.nodeType === 1 ? e.target : (e.target && e.target.parentElement);
-        if (t && typeof t.closest === 'function' && t.closest('#sidebar-context-menu')) return;
-        close();
+  document.addEventListener("mousedown", (e) => {
+    if (!menu.classList.contains("open")) return;
+    const t =
+      e.target && e.target.nodeType === 1
+        ? e.target
+        : e.target && e.target.parentElement;
+    if (
+      t &&
+      typeof t.closest === "function" &&
+      t.closest("#sidebar-context-menu")
+    )
+      return;
+    close();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") close();
+  });
+  window.addEventListener("resize", close);
+  window.addEventListener("scroll", close, true);
+
+  window._openSidebarContextMenu = function (
+    tab,
+    item,
+    itemIndex,
+    arrayIndex,
+    x,
+    y,
+    contextMeta,
+  ) {
+    close();
+    const isBible = tab === "bible";
+    const isSong = tab === "songs";
+    const isSchedule = tab === "schedule";
+    const items = [];
+
+    /* ── Common actions ── */
+    if (!isSchedule) {
+      items.push({
+        label: t("common_add_to_setlist"),
+        icon: "+",
+        action: () => {
+          const list = isSong
+            ? songs
+            : activeBibleVersion
+              ? bibles[activeBibleVersion]
+              : [];
+          if (list[itemIndex]) {
+            insertIntoSchedule(
+              { ...list[itemIndex] },
+              {
+                successMessage: t("setlist_added"),
+                duplicateMessage: t("setlist_duplicate_moved_top"),
+              },
+            );
+          }
+          close();
+        },
       });
-      document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
-      window.addEventListener('resize', close);
-      window.addEventListener('scroll', close, true);
+    }
 
-      window._openSidebarContextMenu = function(tab, item, itemIndex, arrayIndex, x, y, contextMeta) {
-        close();
-        const isBible = (tab === 'bible');
-        const isSong = (tab === 'songs');
-        const isSchedule = (tab === 'schedule');
-        const items = [];
-
-        /* ── Common actions ── */
-        if (!isSchedule) {
-          items.push({ label: t('common_add_to_setlist'), icon: '+', action: () => {
-            const list = isSong ? songs : (activeBibleVersion ? bibles[activeBibleVersion] : []);
-            if (list[itemIndex]) {
-              insertIntoSchedule({ ...list[itemIndex] }, {
-                successMessage: t('setlist_added'),
-                duplicateMessage: t('setlist_duplicate_moved_top')
-              });
-            }
-            close();
-          }});
-        }
-
-        if (isBible) {
-          items.push({ label: t('common_project_live'), icon: '▶', action: () => {
-            buttonContextTab = 'bible';
-            const verseFromSearch = contextMeta && contextMeta.bibleVerse != null
+    if (isBible) {
+      items.push({
+        label: t("common_project_live"),
+        icon: "▶",
+        action: () => {
+          buttonContextTab = "bible";
+          const verseFromSearch =
+            contextMeta && contextMeta.bibleVerse != null
               ? String(contextMeta.bibleVerse).trim()
-              : '';
-            if (verseFromSearch) {
-              activateBibleSearchResult(itemIndex, verseFromSearch);
-            } else {
-              selectItem(itemIndex);
-            }
-            projectLive(true);
-            close();
-          }});
-        }
-
-        if (isSong) {
-          items.push({ label: t('common_project_live'), icon: '▶', action: () => {
-            buttonContextTab = 'songs';
+              : "";
+          if (verseFromSearch) {
+            activateBibleSearchResult(itemIndex, verseFromSearch);
+          } else {
             selectItem(itemIndex);
-            projectLive(true);
+          }
+          projectLive(true);
+          close();
+        },
+      });
+    }
+
+    if (isSong) {
+      items.push({
+        label: t("common_project_live"),
+        icon: "▶",
+        action: () => {
+          buttonContextTab = "songs";
+          selectItem(itemIndex);
+          projectLive(true);
+          close();
+        },
+      });
+      items.push({
+        label: t("common_rename_song"),
+        icon: "✎",
+        action: () => {
+          const target = songs[itemIndex];
+          if (!target) {
             close();
-          }});
-          items.push({ label: t('common_rename_song'), icon: '✎', action: () => {
-            const target = songs[itemIndex];
-            if (!target) { close(); return; }
-            showConfirm(t('common_rename_song'), t('common_enter_new_song_title'), (inputValue) => {
+            return;
+          }
+          showConfirm(
+            t("common_rename_song"),
+            t("common_enter_new_song_title"),
+            (inputValue) => {
               renameSongTitle(itemIndex, inputValue);
-            }, true, target.title || '');
-            close();
-          }});
-        }
+            },
+            true,
+            target.title || "",
+          );
+          close();
+        },
+      });
+    }
 
-        if (!isSchedule) {
-          items.push({ type: 'sep' });
-          items.push({
-            label: t('common_edit'),
-            icon: '✎',
-            disabled: isBible,
-            action: () => {
-              if (isBible) { close(); return; }
-              buttonContextTab = tab;
-              selectItem(itemIndex);
-              close();
-            }
-          });
-        }
-
-        if (isSchedule) {
-          items.push({ label: t('common_project_live'), icon: '▶', action: () => {
-            scheduleReturnTarget = buildScheduleRestoreTarget(item);
-            buttonContextTab = 'schedule';
-            selectItem(arrayIndex);
-            projectLive(true);
+    if (!isSchedule) {
+      items.push({ type: "sep" });
+      items.push({
+        label: t("common_edit"),
+        icon: "✎",
+        disabled: isBible,
+        action: () => {
+          if (isBible) {
             close();
-          }});
-          items.push({ type: 'sep' });
-          items.push({ label: t('common_move_to_top'), icon: '↑', action: () => {
-            if (arrayIndex > 0) {
-              const moved = schedule.splice(arrayIndex, 1)[0];
-              schedule.unshift(moved);
-              saveState(); saveToStorageDebounced(); renderSongs();
-            }
-            close();
-          }});
-          items.push({ label: t('common_move_to_bottom'), icon: '↓', action: () => {
-            if (arrayIndex < schedule.length - 1) {
-              const moved = schedule.splice(arrayIndex, 1)[0];
-              schedule.push(moved);
-              saveState(); saveToStorageDebounced(); renderSongs();
-            }
-            close();
-          }});
-          items.push({ type: 'sep' });
-          items.push({ label: t('common_remove_from_setlist'), icon: '✕', danger: true, action: () => {
-            schedule.splice(arrayIndex, 1);
-            saveState(); saveToStorageDebounced(); renderSongs();
-            showToast(t('setlist_removed'));
-            close();
-          }});
-        }
-
-        if (!isSchedule) {
-          items.push({
-            label: t('common_delete'),
-            icon: '✕',
-            danger: true,
-            disabled: isBible,
-            action: () => {
-              if (isBible) { close(); return; }
-              deleteItem(itemIndex, new MouseEvent('click'));
-              close();
-            }
-          });
-        }
-
-        /* ── Build menu DOM ── */
-        const groupTitle = document.createElement('div');
-        groupTitle.className = 'sl-ctx-group-title';
-        groupTitle.textContent = (item.title || 'Item').substring(0, 40);
-        menu.appendChild(groupTitle);
-
-        items.forEach(it => {
-          if (it.type === 'sep') {
-            const sep = document.createElement('div');
-            sep.className = 'sl-ctx-sep';
-            menu.appendChild(sep);
             return;
           }
-          const btn = document.createElement('button');
-          btn.className = 'sl-ctx-item' + (it.danger ? ' danger' : '');
-          btn.textContent = it.label;
-          btn.disabled = !!it.disabled;
-          btn.onclick = it.action;
-          menu.appendChild(btn);
-        });
+          buttonContextTab = tab;
+          selectItem(itemIndex);
+          close();
+        },
+      });
+    }
 
-        /* ── Position ── */
-        menu.classList.add('open');
-        menu.setAttribute('aria-hidden', 'false');
-        const rect = menu.getBoundingClientRect();
-        const maxX = window.innerWidth - rect.width - 8;
-        const maxY = window.innerHeight - rect.height - 8;
-        menu.style.left = Math.max(4, Math.min(x, maxX)) + 'px';
-        menu.style.top = Math.max(4, Math.min(y, maxY)) + 'px';
-      };
-    })();
+    if (isSchedule) {
+      items.push({
+        label: t("common_project_live"),
+        icon: "▶",
+        action: () => {
+          scheduleReturnTarget = buildScheduleRestoreTarget(item);
+          buttonContextTab = "schedule";
+          selectItem(arrayIndex);
+          projectLive(true);
+          close();
+        },
+      });
+      items.push({ type: "sep" });
+      items.push({
+        label: t("common_move_to_top"),
+        icon: "↑",
+        action: () => {
+          if (arrayIndex > 0) {
+            const moved = schedule.splice(arrayIndex, 1)[0];
+            schedule.unshift(moved);
+            saveState();
+            saveToStorageDebounced();
+            renderSongs();
+          }
+          close();
+        },
+      });
+      items.push({
+        label: t("common_move_to_bottom"),
+        icon: "↓",
+        action: () => {
+          if (arrayIndex < schedule.length - 1) {
+            const moved = schedule.splice(arrayIndex, 1)[0];
+            schedule.push(moved);
+            saveState();
+            saveToStorageDebounced();
+            renderSongs();
+          }
+          close();
+        },
+      });
+      items.push({ type: "sep" });
+      items.push({
+        label: t("common_remove_from_setlist"),
+        icon: "✕",
+        danger: true,
+        action: () => {
+          schedule.splice(arrayIndex, 1);
+          saveState();
+          saveToStorageDebounced();
+          renderSongs();
+          showToast(t("setlist_removed"));
+          close();
+        },
+      });
+    }
 
-    function renderSongs() {
-      const list = document.getElementById('song-list');
-      if (!list) return;
-      const qRaw = document.getElementById('song-search').value || "";
-      const q = normalizeSearchText(qRaw);
-      list.replaceChildren();
-      list._navMirrorItems = [];
-      if (sidebarTab === 'bible' && qRaw.trim().length >= 2 && !isBibleReferenceQuery(qRaw)) {
-        renderBibleSearchResults(qRaw);
+    if (!isSchedule) {
+      items.push({
+        label: t("common_delete"),
+        icon: "✕",
+        danger: true,
+        disabled: isBible,
+        action: () => {
+          if (isBible) {
+            close();
+            return;
+          }
+          deleteItem(itemIndex, new MouseEvent("click"));
+          close();
+        },
+      });
+    }
+
+    /* ── Build menu DOM ── */
+    const groupTitle = document.createElement("div");
+    groupTitle.className = "sl-ctx-group-title";
+    groupTitle.textContent = (item.title || "Item").substring(0, 40);
+    menu.appendChild(groupTitle);
+
+    items.forEach((it) => {
+      if (it.type === "sep") {
+        const sep = document.createElement("div");
+        sep.className = "sl-ctx-sep";
+        menu.appendChild(sep);
         return;
       }
-      currentSearchPos = null;
-      let displayList = getButtonContextList();
-      let displayIndices = null;
-      if (buttonContextTab === 'bible' && sidebarTab === 'bible') {
-        const selectedBook = document.getElementById('bible-book-select')?.value || '';
-        const bookKey = normalizeBookName(selectedBook);
-        if (bookKey) {
-          const filtered = [];
-          const indices = [];
-          displayList.forEach((item, idx) => {
-            const itemBook = item?.book || extractBookAndChapter(item).book;
-            if (normalizeBookName(itemBook) === bookKey) {
-              filtered.push(item);
-              indices.push(idx);
-            }
-          });
-          displayList = filtered;
-          displayIndices = indices;
+      const btn = document.createElement("button");
+      btn.className = "sl-ctx-item" + (it.danger ? " danger" : "");
+      btn.textContent = it.label;
+      btn.disabled = !!it.disabled;
+      btn.onclick = it.action;
+      menu.appendChild(btn);
+    });
+
+    /* ── Position ── */
+    menu.classList.add("open");
+    menu.setAttribute("aria-hidden", "false");
+    const rect = menu.getBoundingClientRect();
+    const maxX = window.innerWidth - rect.width - 8;
+    const maxY = window.innerHeight - rect.height - 8;
+    menu.style.left = Math.max(4, Math.min(x, maxX)) + "px";
+    menu.style.top = Math.max(4, Math.min(y, maxY)) + "px";
+  };
+})();
+
+function renderSongs() {
+  const list = document.getElementById("song-list");
+  if (!list) return;
+  const qRaw = document.getElementById("song-search").value || "";
+  const q = normalizeSearchText(qRaw);
+  list.replaceChildren();
+  list._navMirrorItems = [];
+  if (
+    sidebarTab === "bible" &&
+    qRaw.trim().length >= 2 &&
+    !isBibleReferenceQuery(qRaw)
+  ) {
+    renderBibleSearchResults(qRaw);
+    return;
+  }
+  currentSearchPos = null;
+  let displayList = getButtonContextList();
+  let displayIndices = null;
+  if (buttonContextTab === "bible" && sidebarTab === "bible") {
+    const selectedBook =
+      document.getElementById("bible-book-select")?.value || "";
+    const bookKey = normalizeBookName(selectedBook);
+    if (bookKey) {
+      const filtered = [];
+      const indices = [];
+      displayList.forEach((item, idx) => {
+        const itemBook = item?.book || extractBookAndChapter(item).book;
+        if (normalizeBookName(itemBook) === bookKey) {
+          filtered.push(item);
+          indices.push(idx);
         }
-      }
-      const frag = document.createDocumentFragment();
-      const navMirrorItems = [];
-      displayList.forEach((s, i) => {
-        if (q && !getItemSearchableText(s).includes(q)) return;
-        const itemIndex = (sidebarTab === 'bible' && displayIndices) ? displayIndices[i] : i;
-        const div = document.createElement('div');
-        div.className = 'song-item' + (currentItem === s ? ' active' : '');
-        div.dataset.index = String(itemIndex);
-        const left = document.createElement('span');
-        left.textContent = s.title;
-        const right = document.createElement('div');
-        right.style.display = 'flex';
-        right.style.alignItems = 'center';
-        const isScheduleUi = (sidebarTab === 'schedule' && buttonContextTab === 'schedule');
-        if (isScheduleUi) {
-          const handle = document.createElement('span');
-          handle.className = 'drag-handle'; handle.textContent = '☰';
-          right.appendChild(handle);
-          const del = document.createElement('span');
-          del.style.cursor = 'pointer'; del.style.marginLeft = '12px'; del.textContent = '✕';
-          del.onclick = (e) => { e.stopPropagation(); removeFromSet(i, e) };
-          right.appendChild(del);
-          div.draggable = true;
-          div.addEventListener('dragstart', (e) => { dragIndex = i; div.classList.add('dragging') });
-          div.addEventListener('dragend', () => { dragIndex = null; div.classList.remove('dragging'); [...list.children].forEach(ch => ch.classList.remove('drop-target')) });
-          div.addEventListener('dragover', (e) => { e.preventDefault(); div.classList.add('drop-target') });
-          div.addEventListener('dragleave', () => div.classList.remove('drop-target'));
-          div.addEventListener('drop', (e) => { e.preventDefault(); div.classList.remove('drop-target'); if (dragIndex == null || dragIndex === i) return; const item = schedule.splice(dragIndex, 1)[0]; schedule.splice(i, 0, item); saveState(); saveToStorageDebounced(); renderSongs() });
-        } else {
-          const add = document.createElement('span');
-          add.style.color = 'var(--success)'; add.style.marginRight = '12px'; add.style.cursor = 'pointer'; add.textContent = '+';
-          add.onclick = (e) => addToSet(itemIndex, e);
-          right.appendChild(add);
-          if (sidebarTab !== 'bible') {
-            const del = document.createElement('span');
-            del.style.cursor = 'pointer'; del.textContent = '✕';
-            del.onclick = (e) => deleteItem(itemIndex, e);
-            right.appendChild(del);
-          }
-        }
-        div.appendChild(left);
-        div.appendChild(right);
-        if (sidebarTab === 'schedule' && buttonContextTab === 'schedule') {
-          const scheduleTarget = buildScheduleRestoreTarget(s);
-          div.onclick = () => {
-            scheduleReturnTarget = scheduleTarget;
-            buttonContextTab = 'schedule';
-            selectItem(itemIndex);
-            const setlistBehavior = (typeof getSetlistSettingsSnapshot === 'function')
-              ? getSetlistSettingsSnapshot()
-              : DEFAULT_SETLIST_SETTINGS;
-            if (setlistBehavior.autoGoLiveOnSelect) {
-              projectLive(true);
-            }
-          };
-          div.ondblclick = () => {
-            scheduleReturnTarget = scheduleTarget;
-            buttonContextTab = 'schedule';
-            selectItem(itemIndex);
-            projectLive(true);
-          };
-        } else {
-          div.onclick = () => {
-            buttonContextTab = sidebarTab;
-            selectItem(itemIndex);
-          };
-        }
-        /* ── Right-click context menu ── */
-        div.addEventListener('contextmenu', (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          if (typeof window._openSidebarContextMenu !== 'function') return;
-          window._openSidebarContextMenu(sidebarTab, s, itemIndex, i, e.clientX, e.clientY);
-        });
-        navMirrorItems.push({
-          row: div,
-          title: s.title || '',
-          snippet: '',
-          active: currentItem === s,
-          activate: () => {
-            if (sidebarTab === 'schedule' && buttonContextTab === 'schedule') {
-              scheduleReturnTarget = buildScheduleRestoreTarget(s);
-              buttonContextTab = 'schedule';
-              selectItem(itemIndex);
-              return;
-            }
-            buttonContextTab = sidebarTab;
-            selectItem(itemIndex);
-          },
-          contextMenu: (clientX, clientY) => {
-            if (typeof window._openSidebarContextMenu !== 'function') return;
-            window._openSidebarContextMenu(sidebarTab, s, itemIndex, i, clientX, clientY);
-          }
-        });
-        frag.appendChild(div);
       });
-      list.appendChild(frag);
-      list._navMirrorItems = navMirrorItems;
-      if (typeof window._refreshNavMirrorResults === 'function') {
-        window._refreshNavMirrorResults();
-      }
-      renderFocusedMainPanel();
+      displayList = filtered;
+      displayIndices = indices;
     }
-
-    function configureImportAccept() {
-      const input = document.getElementById('import-file');
-      if (!input) return;
-      // OBS/CEF has inconsistent behavior with mixed extension filters.
-      // Show all files in picker, then enforce allowed extensions in handleImport().
-      input.accept = '';
-    }
-
-    function triggerImport() {
-      if ((typeof sidebarTab !== 'undefined' && sidebarTab === 'media') || document.body.dataset.sidebarTab === 'media') {
-        if (window.bspMedia && typeof window.bspMedia.openFilePicker === 'function') {
-          window.bspMedia.openFilePicker();
-        } else {
-          const mediaInput = document.getElementById('media-file-input');
-          if (mediaInput) mediaInput.click();
-        }
-        return;
-      }
-      configureImportAccept();
-      document.getElementById('import-file').click();
-    }
-
-    async function handleImport(input) {
-      let importedAnyBible = false;
-      let importedCount = 0;
-      let skippedUnsupported = 0;
-      let hadImportError = false;
-      let hadBiblePersistError = false;
-      for (const file of input.files) {
-        try {
-          const name = file.name.toLowerCase();
-          const text = await file.text();
-          if (name.endsWith('.xml')) {
-            const xml = new DOMParser().parseFromString(text, "text/xml");
-            const bibleRoot = xml.querySelector('bible');
-            const xmlBibleRoot = xml.querySelector('XMLBIBLE') || xml.querySelector('xmlbible');
-            const verName = bibleRoot?.getAttribute('translation') ||
-                           bibleRoot?.getAttribute('name') ||
-                           bibleRoot?.getAttribute('n') ||
-                           xmlBibleRoot?.getAttribute('biblename') ||
-                           xmlBibleRoot?.getAttribute('name') ||
-                           file.name.split('.')[0].toUpperCase();
-            const parsed = parseBible(xml, verName);
-            if (bibles[verName]) {
-              showConfirm('Version Exists', `Version "${verName}" already exists. Replace?`, async () => {
-                bibles[verName] = parsed;
-                clearBibleSearchCache(verName);
-                if (!activeBibleVersion || !bibles[activeBibleVersion]) {
-                  activeBibleVersion = verName;
-                }
-                saveState();
-                renderVersionBar();
-                updateBibleLists();
-                renderSongs();
-                ensureSelectionFallback();
-                saveToStorageDebounced();
-                try {
-                  await idbPut(STORE_BIBLES, buildBibleRecord(verName, parsed, { isNew: false }));
-                  await flushAppState();
-                  showToast(t('bible_version_imported'));
-                } catch (e) {
-                  console.error('Bible import persist failed', e);
-                  showToast(t('bible_import_persist_failed'));
-                }
-              });
-              return;
-            }
-            bibles[verName] = parsed;
-            clearBibleSearchCache(verName);
-            if (!activeBibleVersion || !bibles[activeBibleVersion]) {
-              activeBibleVersion = verName;
-            }
-            try {
-              await idbPut(STORE_BIBLES, buildBibleRecord(verName, parsed, { isNew: true }));
-            } catch (e) {
-              hadBiblePersistError = true;
-              console.error('Bible import persist failed', e);
-            }
-            importedAnyBible = true;
-            importedCount += 1;
-            renderVersionBar();
-            updateBibleLists();
-          } else if (name.endsWith('.txt')) {
-            const title = file.name.split('.')[0];
-            const newSong = {
-              id: createId('song', title),
-              title,
-              content: text,
-              text,
-              translatedLyrics: '',
-              translationLanguage: getSongBilingualSettings().targetLanguage,
-              translationStatus: 'idle',
-              translationLocked: false,
-              translatedAt: 0,
-              translationHash: computeTranslationHash(text, getSongBilingualSettings().targetLanguage),
-              searchableText: normalizeSearchText(`${title}\n${text}`),
-              createdAt: Date.now(),
-              updatedAt: Date.now()
-            };
-            songs.push(newSong);
-            idbPut(STORE_SONGS, buildSongRecord(newSong, { isNew: true })).catch(() => {});
-            maybeTranslateImportedSong(newSong);
-            importedCount += 1;
-          } else {
-            skippedUnsupported += 1;
-            continue;
-          }
-        } catch (e) {
-          hadImportError = true;
-          console.error('Import failed for file', file && file.name ? file.name : '(unknown file)', e);
-        }
-      }
-      saveState();
-      saveToStorageDebounced();
-      if (importedAnyBible) {
-        try { await flushAppState(); } catch (_) {}
-      }
-      if (hadBiblePersistError) {
-        showToast(t('bible_import_persist_failed'));
-      }
-      if (hadImportError) {
-        showToast(t('import_failed'));
-      }
-      if (skippedUnsupported > 0) {
-        showToast(t('import_skipped_unsupported').replace('{count}', String(skippedUnsupported)));
-      }
-      renderSongs();
-      ensureSelectionFallback();
-      input.value = "";
-      if (importedCount > 0) {
-        showToast(importedCount === 1
-          ? t('import_file_imported')
-          : t('import_files_imported').replace('{count}', String(importedCount)));
-      } else if (!skippedUnsupported) {
-        showToast(t('common_no_file_selected'));
-      }
-    }
-
-    function formatBackupFilename(date) {
-      const d = date || new Date();
-      const pad = (n) => String(n).padStart(2, '0');
-      const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
-      return `BibleSongPro_Backup_${stamp}.json`;
-    }
-
-    function mergeAppStateWithDefaults(raw) {
-      const base = buildDefaultAppState();
-      const next = (raw && typeof raw === 'object') ? raw : {};
-      const nextUi = next.ui || {};
-      const nextSearchText = nextUi.searchText;
-      const mergedSearchText = { ...DEFAULT_SEARCH_QUERIES };
-      if (nextSearchText && typeof nextSearchText === 'object' && !Array.isArray(nextSearchText)) {
-        SEARCH_TABS.forEach(tab => {
-          if (nextSearchText[tab] != null) mergedSearchText[tab] = String(nextSearchText[tab]);
-        });
-      } else if (typeof nextSearchText === 'string') {
-        SEARCH_TABS.forEach(tab => {
-          mergedSearchText[tab] = nextSearchText;
-        });
-      }
-      const mergedUi = {
-        ...base.ui,
-        ...nextUi,
-        searchText: mergedSearchText,
-        bibleRecentRefs: sanitizeBibleRefEntries(nextUi.bibleRecentRefs, MAX_BIBLE_RECENT_REFS),
-        biblePinnedRefs: sanitizeBibleRefEntries(nextUi.biblePinnedRefs, MAX_BIBLE_PINNED_REFS),
-        focusedWorkspaceControls: nextUi.focusedWorkspaceControls || base.ui.focusedWorkspaceControls
+  }
+  const frag = document.createDocumentFragment();
+  const navMirrorItems = [];
+  displayList.forEach((s, i) => {
+    if (q && !getItemSearchableText(s).includes(q)) return;
+    const itemIndex =
+      sidebarTab === "bible" && displayIndices ? displayIndices[i] : i;
+    const div = document.createElement("div");
+    div.className = "song-item" + (currentItem === s ? " active" : "");
+    div.dataset.index = String(itemIndex);
+    const left = document.createElement("span");
+    left.textContent = s.title;
+    const right = document.createElement("div");
+    right.style.display = "flex";
+    right.style.alignItems = "center";
+    const isScheduleUi =
+      sidebarTab === "schedule" && buttonContextTab === "schedule";
+    if (isScheduleUi) {
+      const handle = document.createElement("span");
+      handle.className = "drag-handle";
+      handle.textContent = "☰";
+      right.appendChild(handle);
+      const del = document.createElement("span");
+      del.style.cursor = "pointer";
+      del.style.marginLeft = "12px";
+      del.textContent = "✕";
+      del.onclick = (e) => {
+        e.stopPropagation();
+        removeFromSet(i, e);
       };
-      return {
-        ...base,
-        ...next,
-        mode: { ...base.mode, ...(next.mode || {}) },
-        songNav: { ...base.songNav, ...(next.songNav || {}) },
-        bibleNav: { ...base.bibleNav, ...(next.bibleNav || {}) },
-        live: { ...base.live, ...(next.live || {}) },
-        audioMixer: { ...base.audioMixer, ...(next.audioMixer || {}) },
-        ui: mergedUi
-      };
-    }
-
-    function coerceSongRecord(raw) {
-      if (!raw) return null;
-      const text = raw.text || raw.content || '';
-      const seed = {
-        id: raw.id,
-        title: raw.title || raw.name || '',
-        text,
-        content: text,
-        translatedLyrics: raw.translatedLyrics || '',
-        translationLanguage: raw.translationLanguage || '',
-        translationStatus: raw.translationStatus || 'idle',
-        translationLocked: !!raw.translationLocked,
-        translatedAt: raw.translatedAt || 0,
-        translationHash: raw.translationHash || '',
-        bilingualEnabled: !!raw.bilingualEnabled,
-        createdAt: raw.createdAt,
-        updatedAt: raw.updatedAt
-      };
-      if (!seed.title && !seed.text) return null;
-      const record = buildSongRecord(seed, { isNew: false });
-      if (raw.searchableText) record.searchableText = raw.searchableText;
-      if (Array.isArray(raw.normalizedLines)) record.normalizedLines = raw.normalizedLines;
-      if (raw.createdAt) record.createdAt = raw.createdAt;
-      if (raw.updatedAt) record.updatedAt = raw.updatedAt;
-      return record;
-    }
-
-    function coerceBibleRecord(raw) {
-      if (!raw) return null;
-      const id = raw.id || raw.name;
-      if (!id) return null;
-      if (Array.isArray(raw.parsedData)) {
-        return {
-          id,
-          name: raw.name || id,
-          parsedData: raw.parsedData,
-          searchableText: raw.searchableText || normalizeSearchText(raw.name || id),
-          createdAt: raw.createdAt || Date.now(),
-          updatedAt: raw.updatedAt || Date.now()
-        };
-      }
-      if (raw.xmlText) {
-        try {
-          const xml = new DOMParser().parseFromString(raw.xmlText, "text/xml");
-          const parsed = parseBible(xml, raw.name || id);
-          return buildBibleRecord(raw.name || id, parsed, { isNew: false, createdAt: raw.createdAt || null });
-        } catch (e) {
-          return null;
-        }
-      }
-      return null;
-    }
-
-    function normalizeSongRecords(raw) {
-      if (Array.isArray(raw)) return raw.map(coerceSongRecord).filter(Boolean);
-      if (raw && typeof raw === 'object') {
-        return Object.values(raw).map(coerceSongRecord).filter(Boolean);
-      }
-      return [];
-    }
-
-    function normalizeBibleRecords(raw) {
-      if (Array.isArray(raw)) return raw.map(coerceBibleRecord).filter(Boolean);
-      if (raw && typeof raw === 'object') {
-        const out = [];
-        Object.entries(raw).forEach(([id, value]) => {
-          if (Array.isArray(value)) {
-            out.push(buildBibleRecord(id, value, { isNew: false }));
-          } else if (value && typeof value === 'object') {
-            out.push(coerceBibleRecord({ id, ...value }));
-          }
-        });
-        return out.filter(Boolean);
-      }
-      return [];
-    }
-
-    function safeStringify(value) {
-      try {
-        return JSON.stringify(value, null, 2);
-      } catch (e) {
-        return JSON.stringify(value, (key, val) => {
-          if (typeof val === 'function') return undefined;
-          if (val && val.nodeType) return undefined;
-          if (typeof val === 'bigint') return val.toString();
-          if (val instanceof Map) return Array.from(val.entries());
-          if (val instanceof Set) return Array.from(val.values());
-          return val;
-        }, 2);
-      }
-    }
-
-    function showObsBackupOverlay(filename, json) {
-      const isObsBrowserSource = !!window.obsstudio;
-      const existing = document.getElementById('obs-backup-overlay');
-      if (existing) existing.remove();
-      const overlay = document.createElement('div');
-      overlay.id = 'obs-backup-overlay';
-      overlay.style.cssText = 'position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.72);display:flex;align-items:center;justify-content:center;padding:16px;';
-      const panel = document.createElement('div');
-      panel.style.cssText = 'width:min(980px,96vw);max-height:92vh;background:#0f1117;border:1px solid rgba(255,255,255,0.16);border-radius:10px;display:flex;flex-direction:column;overflow:hidden;';
-      const header = document.createElement('div');
-      header.style.cssText = 'padding:10px 12px;border-bottom:1px solid rgba(255,255,255,0.12);display:flex;align-items:center;gap:8px;color:#e8ecf5;font:600 12px/1.2 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;';
-      header.textContent = t('backup_json_title').replace('{filename}', filename);
-      const btnWrap = document.createElement('div');
-      btnWrap.style.cssText = 'margin-left:auto;display:flex;gap:8px;';
-      const btnCopy = document.createElement('button');
-      btnCopy.type = 'button';
-      btnCopy.textContent = 'Copy';
-      btnCopy.style.cssText = 'padding:6px 10px;font-size:11px;border-radius:6px;border:1px solid rgba(255,255,255,0.2);background:#1b2030;color:#fff;cursor:pointer;';
-      const btnSave = document.createElement('button');
-      btnSave.type = 'button';
-      btnSave.textContent = 'Save .json';
-      btnSave.style.cssText = btnCopy.style.cssText;
-      const btnClose = document.createElement('button');
-      btnClose.type = 'button';
-      btnClose.textContent = 'Close';
-      btnClose.style.cssText = 'padding:6px 10px;font-size:11px;border-radius:6px;border:1px solid rgba(255,255,255,0.2);background:#2a1520;color:#fff;cursor:pointer;';
-      btnWrap.appendChild(btnCopy);
-      btnWrap.appendChild(btnSave);
-      btnWrap.appendChild(btnClose);
-      header.appendChild(btnWrap);
-      const body = document.createElement('div');
-      body.style.cssText = 'padding:10px;display:flex;flex-direction:column;gap:8px;';
-      const hint = document.createElement('div');
-      hint.style.cssText = 'color:#c7d2ea;font:500 11px/1.3 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;';
-      hint.textContent = isObsBrowserSource
-        ? t('backup_overlay_obs_hint')
-        : t('backup_overlay_save_hint');
-      const ta = document.createElement('textarea');
-      ta.readOnly = true;
-      ta.value = json;
-      ta.style.cssText = 'width:100%;height:min(72vh,640px);resize:vertical;background:#080b12;color:#eaf0ff;border:1px solid rgba(255,255,255,0.14);border-radius:8px;padding:10px;font:12px/1.35 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;';
-      body.appendChild(hint);
-      body.appendChild(ta);
-      panel.appendChild(header);
-      panel.appendChild(body);
-      overlay.appendChild(panel);
-      document.body.appendChild(overlay);
-      ta.focus();
-      ta.select();
-
-      const close = () => overlay.remove();
-      btnClose.onclick = close;
-      overlay.addEventListener('click', (e) => {
-        if (e.target === overlay) close();
+      right.appendChild(del);
+      div.draggable = true;
+      div.addEventListener("dragstart", (e) => {
+        dragIndex = i;
+        div.classList.add("dragging");
       });
-      btnCopy.onclick = async () => {
-        let ok = false;
-        if (navigator.clipboard?.writeText) {
-          try {
-            await navigator.clipboard.writeText(json);
-            ok = true;
-          } catch (_) {}
+      div.addEventListener("dragend", () => {
+        dragIndex = null;
+        div.classList.remove("dragging");
+        [...list.children].forEach((ch) => ch.classList.remove("drop-target"));
+      });
+      div.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        div.classList.add("drop-target");
+      });
+      div.addEventListener("dragleave", () =>
+        div.classList.remove("drop-target"),
+      );
+      div.addEventListener("drop", (e) => {
+        e.preventDefault();
+        div.classList.remove("drop-target");
+        if (dragIndex == null || dragIndex === i) return;
+        const item = schedule.splice(dragIndex, 1)[0];
+        schedule.splice(i, 0, item);
+        saveState();
+        saveToStorageDebounced();
+        renderSongs();
+      });
+    } else {
+      const add = document.createElement("span");
+      add.style.color = "var(--success)";
+      add.style.marginRight = "12px";
+      add.style.cursor = "pointer";
+      add.textContent = "+";
+      add.onclick = (e) => addToSet(itemIndex, e);
+      right.appendChild(add);
+      if (sidebarTab !== "bible") {
+        const del = document.createElement("span");
+        del.style.cursor = "pointer";
+        del.textContent = "✕";
+        del.onclick = (e) => deleteItem(itemIndex, e);
+        right.appendChild(del);
+      }
+    }
+    div.appendChild(left);
+    div.appendChild(right);
+    if (sidebarTab === "schedule" && buttonContextTab === "schedule") {
+      const scheduleTarget = buildScheduleRestoreTarget(s);
+      div.onclick = () => {
+        scheduleReturnTarget = scheduleTarget;
+        buttonContextTab = "schedule";
+        selectItem(itemIndex);
+        const setlistBehavior =
+          typeof getSetlistSettingsSnapshot === "function"
+            ? getSetlistSettingsSnapshot()
+            : DEFAULT_SETLIST_SETTINGS;
+        if (setlistBehavior.autoGoLiveOnSelect) {
+          projectLive(true);
         }
-        if (!ok) {
-          try {
-            ta.focus();
-            ta.select();
-            ok = !!document.execCommand('copy');
-          } catch (_) {}
-        }
-        showToast(ok ? 'Backup copied to clipboard' : t('common_copy_failed'));
       };
-      btnSave.onclick = async () => {
-        try {
-          const payload = ta && typeof ta.value === 'string' ? ta.value : json;
-          if (typeof window.showSaveFilePicker === 'function') {
-            try {
-              const handle = await window.showSaveFilePicker({
-                suggestedName: filename,
-                types: [{
-                  description: 'JSON Backup',
-                  accept: { 'application/json': ['.json'] }
-                }]
-              });
-              if (handle && typeof handle.createWritable === 'function') {
-                const writable = await handle.createWritable();
-                const encoded = new TextEncoder().encode(payload);
-                await writable.write(encoded);
-                await writable.close();
-                if (typeof handle.getFile === 'function') {
-                  const savedFile = await handle.getFile();
-                  if (!savedFile || !savedFile.size) {
-                    throw new Error('Saved file is empty');
-                  }
-                }
-                showToast(t('backup_saved'));
-                return;
-              }
-            } catch (pickerErr) {
-              if (pickerErr && (pickerErr.name === 'AbortError' || pickerErr.code === 20)) return;
-              console.warn('Backup overlay: save picker failed, falling back', pickerErr);
-            }
-          }
-          let saved = false;
-          try {
-            const dataUrl = 'data:application/octet-stream;charset=utf-8,' + encodeURIComponent(payload);
-            const link = document.createElement('a');
-            link.href = dataUrl;
-            link.download = filename;
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
-            saved = true;
-          } catch (dataErr) {
-            console.warn('Backup overlay: data URI download failed', dataErr);
-          }
-          if (!saved) {
-            try {
-              const blob = new Blob([payload], { type: 'application/json' });
-              const url = URL.createObjectURL(blob);
-              const link = document.createElement('a');
-              link.href = url;
-              link.download = filename;
-              document.body.appendChild(link);
-              link.click();
-              link.remove();
-              setTimeout(() => URL.revokeObjectURL(url), 30000);
-              saved = true;
-            } catch (blobErr) {
-              console.warn('Backup overlay: blob download failed', blobErr);
-            }
-          }
-          if (saved) {
-            showToast(t('backup_save_triggered_downloads'));
-          } else {
-            let copied = false;
-            if (navigator.clipboard?.writeText) {
-              try { await navigator.clipboard.writeText(payload); copied = true; } catch (_) {}
-            }
-            showToast(copied ? t('backup_save_failed_clipboard_fallback') : t('backup_save_failed'));
-          }
-        } catch (_) {
-          showToast(t('backup_save_failed'));
-        }
+      div.ondblclick = () => {
+        scheduleReturnTarget = scheduleTarget;
+        buttonContextTab = "schedule";
+        selectItem(itemIndex);
+        projectLive(true);
+      };
+    } else {
+      div.onclick = () => {
+        buttonContextTab = sidebarTab;
+        selectItem(itemIndex);
       };
     }
-
-    async function exportBackup() {
-      try {
-        const filename = formatBackupFilename(new Date());
-        let saveHandle = null;
-        const isObsBrowserSource = !!(window.obsstudio && !(window.BSPDesktop && typeof window.BSPDesktop.saveRecordingFile === 'function'));
-        if (typeof window.showSaveFilePicker === 'function') {
-          try {
-            saveHandle = await window.showSaveFilePicker({
-              suggestedName: filename,
-              types: [{
-                description: 'JSON Backup',
-                accept: { 'application/json': ['.json'] }
-              }]
-            });
-          } catch (pickErr) {
-            // User-cancel should not show a failure toast.
-            if (pickErr && (pickErr.name === 'AbortError' || pickErr.code === 20)) return;
-            console.warn('Backup export: save picker unavailable/fallback', pickErr);
-          }
-        }
-        let dbOk = true;
-        await openDb().catch(err => {
-          console.error('Backup export: openDb failed', err);
-          dbPromise = null;
-          dbOk = false;
-        });
-        let songRecords = [];
-        let bibleRecords = [];
-        let stateEntry = null;
-        if (dbOk) {
-          try {
-            const results = await Promise.all([
-              dbGetAll(STORE_SONGS),
-              dbGetAll(STORE_BIBLES),
-              idbGet(STORE_STATE, 'appState')
-            ]);
-            songRecords = results[0] || [];
-            bibleRecords = results[1] || [];
-            stateEntry = results[2] || null;
-          } catch (e) {
-            console.error('Backup export: IndexedDB read failed', e);
-            dbOk = false;
-          }
-        }
-        if (!dbOk) {
-          console.warn('Backup export: falling back to in-memory data');
-        }
-        if (!songRecords.length && songs.length) {
-          songRecords = songs.map(coerceSongRecord).filter(Boolean);
-        }
-        if (!bibleRecords.length && Object.keys(bibles).length) {
-          bibleRecords = Object.keys(bibles).map(name => buildBibleRecord(name, bibles[name] || [], { isNew: false })).filter(Boolean);
-        }
-        if (stateReady && appState) {
-          syncAppStateFromUi();
-        }
-        const stateValue = appState || ((stateEntry && stateEntry.value) ? stateEntry.value : buildDefaultAppState());
-        const settings = (stateValue.settings && typeof stateValue.settings === 'object') ? stateValue.settings : {};
-        if (bgUploadDataUrl != null) settings.bgUploadDataUrl = bgUploadDataUrl;
-        if (bgVideoUploadDataUrl != null) settings.bgVideoUploadDataUrl = bgVideoUploadDataUrl;
-        const backup = {
-          app: 'Bible Song Pro',
-          backupVersion: 1,
-          exportedAt: new Date().toISOString(),
-          data: {
-            songs: songRecords,
-            bibles: bibleRecords,
-            appState: stateValue,
-            settings,
-            ltStyles: settings.ltStyles || ltStyles,
-            customFonts: settings.customFonts || customFonts,
-            presets: Array.isArray(stateValue.presets) ? stateValue.presets : presets,
-            extra: {
-              backgroundUploads: {
-                bgUploadDataUrl: bgUploadDataUrl || '',
-                bgVideoUploadDataUrl: bgVideoUploadDataUrl || ''
-              }
-            }
-          }
-        };
-        const json = safeStringify(backup);
-        if (!json) throw new Error('Backup stringify failed');
-        if (saveHandle) {
-          try {
-            const writable = await saveHandle.createWritable();
-            const encoded = new TextEncoder().encode(json);
-            await writable.write(encoded);
-            await writable.close();
-            if (typeof saveHandle.getFile === 'function') {
-              const savedFile = await saveHandle.getFile();
-              if (!savedFile || !savedFile.size) {
-                throw new Error('Saved file is empty');
-              }
-            }
-            showToast(t('backup_exported'));
-            return;
-          } catch (saveErr) {
-            console.error('Backup export: save picker write failed, falling back', saveErr);
-          }
-        }
-        if (isObsBrowserSource) {
-          let copied = false;
-          if (navigator.clipboard?.writeText) {
-            try {
-              await navigator.clipboard.writeText(json);
-              copied = true;
-            } catch (clipErr) {
-              console.error('Backup export: OBS clipboard fallback failed', clipErr);
-            }
-          }
-          showObsBackupOverlay(filename, json);
-          if (copied) {
-            showToast(t('backup_ready_viewer_opened_copied'));
-            return;
-          }
-          showToast(t('backup_ready_viewer_opened'));
+    /* ── Right-click context menu ── */
+    div.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (typeof window._openSidebarContextMenu !== "function") return;
+      window._openSidebarContextMenu(
+        sidebarTab,
+        s,
+        itemIndex,
+        i,
+        e.clientX,
+        e.clientY,
+      );
+    });
+    navMirrorItems.push({
+      row: div,
+      title: s.title || "",
+      snippet: "",
+      active: currentItem === s,
+      activate: () => {
+        if (sidebarTab === "schedule" && buttonContextTab === "schedule") {
+          scheduleReturnTarget = buildScheduleRestoreTarget(s);
+          buttonContextTab = "schedule";
+          selectItem(itemIndex);
           return;
         }
+        buttonContextTab = sidebarTab;
+        selectItem(itemIndex);
+      },
+      contextMenu: (clientX, clientY) => {
+        if (typeof window._openSidebarContextMenu !== "function") return;
+        window._openSidebarContextMenu(
+          sidebarTab,
+          s,
+          itemIndex,
+          i,
+          clientX,
+          clientY,
+        );
+      },
+    });
+    frag.appendChild(div);
+  });
+  list.appendChild(frag);
+  list._navMirrorItems = navMirrorItems;
+  if (typeof window._refreshNavMirrorResults === "function") {
+    window._refreshNavMirrorResults();
+  }
+  renderFocusedMainPanel();
+}
 
-        let downloadSucceeded = false;
+function configureImportAccept() {
+  const input = document.getElementById("import-file");
+  if (!input) return;
+  // OBS/CEF has inconsistent behavior with mixed extension filters.
+  // Show all files in picker, then enforce allowed extensions in handleImport().
+  input.accept = "";
+}
+
+function triggerImport() {
+  if (
+    (typeof sidebarTab !== "undefined" && sidebarTab === "media") ||
+    document.body.dataset.sidebarTab === "media"
+  ) {
+    if (
+      window.bspMedia &&
+      typeof window.bspMedia.openFilePicker === "function"
+    ) {
+      window.bspMedia.openFilePicker();
+    } else {
+      const mediaInput = document.getElementById("media-file-input");
+      if (mediaInput) mediaInput.click();
+    }
+    return;
+  }
+  configureImportAccept();
+  document.getElementById("import-file").click();
+}
+
+async function handleImport(input) {
+  let importedAnyBible = false;
+  let importedCount = 0;
+  let skippedUnsupported = 0;
+  let hadImportError = false;
+  let hadBiblePersistError = false;
+  for (const file of input.files) {
+    try {
+      const name = file.name.toLowerCase();
+      const text = await file.text();
+      if (name.endsWith(".xml")) {
+        const xml = new DOMParser().parseFromString(text, "text/xml");
+        const bibleRoot = xml.querySelector("bible");
+        const xmlBibleRoot =
+          xml.querySelector("XMLBIBLE") || xml.querySelector("xmlbible");
+        const verName =
+          bibleRoot?.getAttribute("translation") ||
+          bibleRoot?.getAttribute("name") ||
+          bibleRoot?.getAttribute("n") ||
+          xmlBibleRoot?.getAttribute("biblename") ||
+          xmlBibleRoot?.getAttribute("name") ||
+          file.name.split(".")[0].toUpperCase();
+        const parsed = parseBible(xml, verName);
+        if (bibles[verName]) {
+          showConfirm(
+            "Version Exists",
+            `Version "${verName}" already exists. Replace?`,
+            async () => {
+              bibles[verName] = parsed;
+              clearBibleSearchCache(verName);
+              if (!activeBibleVersion || !bibles[activeBibleVersion]) {
+                activeBibleVersion = verName;
+              }
+              saveState();
+              renderVersionBar();
+              updateBibleLists();
+              renderSongs();
+              ensureSelectionFallback();
+              saveToStorageDebounced();
+              try {
+                await idbPut(
+                  STORE_BIBLES,
+                  buildBibleRecord(verName, parsed, { isNew: false }),
+                );
+                await flushAppState();
+                showToast(t("bible_version_imported"));
+              } catch (e) {
+                console.error("Bible import persist failed", e);
+                showToast(t("bible_import_persist_failed"));
+              }
+            },
+          );
+          return;
+        }
+        bibles[verName] = parsed;
+        clearBibleSearchCache(verName);
+        if (!activeBibleVersion || !bibles[activeBibleVersion]) {
+          activeBibleVersion = verName;
+        }
         try {
-          const blob = new Blob([json], { type: 'application/json' });
+          await idbPut(
+            STORE_BIBLES,
+            buildBibleRecord(verName, parsed, { isNew: true }),
+          );
+        } catch (e) {
+          hadBiblePersistError = true;
+          console.error("Bible import persist failed", e);
+        }
+        importedAnyBible = true;
+        importedCount += 1;
+        renderVersionBar();
+        updateBibleLists();
+      } else if (name.endsWith(".txt")) {
+        const title = file.name.split(".")[0];
+        const newSong = {
+          id: createId("song", title),
+          title,
+          content: text,
+          text,
+          translatedLyrics: "",
+          translationLanguage: getSongBilingualSettings().targetLanguage,
+          translationStatus: "idle",
+          translationLocked: false,
+          translatedAt: 0,
+          translationHash: computeTranslationHash(
+            text,
+            getSongBilingualSettings().targetLanguage,
+          ),
+          searchableText: normalizeSearchText(`${title}\n${text}`),
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+        songs.push(newSong);
+        idbPut(STORE_SONGS, buildSongRecord(newSong, { isNew: true })).catch(
+          () => {},
+        );
+        maybeTranslateImportedSong(newSong);
+        importedCount += 1;
+      } else {
+        skippedUnsupported += 1;
+        continue;
+      }
+    } catch (e) {
+      hadImportError = true;
+      console.error(
+        "Import failed for file",
+        file && file.name ? file.name : "(unknown file)",
+        e,
+      );
+    }
+  }
+  saveState();
+  saveToStorageDebounced();
+  if (importedAnyBible) {
+    try {
+      await flushAppState();
+    } catch (_) {}
+  }
+  if (hadBiblePersistError) {
+    showToast(t("bible_import_persist_failed"));
+  }
+  if (hadImportError) {
+    showToast(t("import_failed"));
+  }
+  if (skippedUnsupported > 0) {
+    showToast(
+      t("import_skipped_unsupported").replace(
+        "{count}",
+        String(skippedUnsupported),
+      ),
+    );
+  }
+  renderSongs();
+  ensureSelectionFallback();
+  input.value = "";
+  if (importedCount > 0) {
+    showToast(
+      importedCount === 1
+        ? t("import_file_imported")
+        : t("import_files_imported").replace("{count}", String(importedCount)),
+    );
+  } else if (!skippedUnsupported) {
+    showToast(t("common_no_file_selected"));
+  }
+}
+
+function formatBackupFilename(date) {
+  const d = date || new Date();
+  const pad = (n) => String(n).padStart(2, "0");
+  const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
+  return `BibleSongPro_Backup_${stamp}.json`;
+}
+
+function mergeAppStateWithDefaults(raw) {
+  const base = buildDefaultAppState();
+  const next = raw && typeof raw === "object" ? raw : {};
+  const nextUi = next.ui || {};
+  const nextSearchText = nextUi.searchText;
+  const mergedSearchText = { ...DEFAULT_SEARCH_QUERIES };
+  if (
+    nextSearchText &&
+    typeof nextSearchText === "object" &&
+    !Array.isArray(nextSearchText)
+  ) {
+    SEARCH_TABS.forEach((tab) => {
+      if (nextSearchText[tab] != null)
+        mergedSearchText[tab] = String(nextSearchText[tab]);
+    });
+  } else if (typeof nextSearchText === "string") {
+    SEARCH_TABS.forEach((tab) => {
+      mergedSearchText[tab] = nextSearchText;
+    });
+  }
+  const mergedUi = {
+    ...base.ui,
+    ...nextUi,
+    searchText: mergedSearchText,
+    bibleRecentRefs: sanitizeBibleRefEntries(
+      nextUi.bibleRecentRefs,
+      MAX_BIBLE_RECENT_REFS,
+    ),
+    biblePinnedRefs: sanitizeBibleRefEntries(
+      nextUi.biblePinnedRefs,
+      MAX_BIBLE_PINNED_REFS,
+    ),
+    focusedWorkspaceControls:
+      nextUi.focusedWorkspaceControls || base.ui.focusedWorkspaceControls,
+  };
+  return {
+    ...base,
+    ...next,
+    mode: { ...base.mode, ...(next.mode || {}) },
+    songNav: { ...base.songNav, ...(next.songNav || {}) },
+    bibleNav: { ...base.bibleNav, ...(next.bibleNav || {}) },
+    live: { ...base.live, ...(next.live || {}) },
+    audioMixer: { ...base.audioMixer, ...(next.audioMixer || {}) },
+    ui: mergedUi,
+  };
+}
+
+function coerceSongRecord(raw) {
+  if (!raw) return null;
+  const text = raw.text || raw.content || "";
+  const seed = {
+    id: raw.id,
+    title: raw.title || raw.name || "",
+    text,
+    content: text,
+    translatedLyrics: raw.translatedLyrics || "",
+    translationLanguage: raw.translationLanguage || "",
+    translationStatus: raw.translationStatus || "idle",
+    translationLocked: !!raw.translationLocked,
+    translatedAt: raw.translatedAt || 0,
+    translationHash: raw.translationHash || "",
+    bilingualEnabled: !!raw.bilingualEnabled,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+  if (!seed.title && !seed.text) return null;
+  const record = buildSongRecord(seed, { isNew: false });
+  if (raw.searchableText) record.searchableText = raw.searchableText;
+  if (Array.isArray(raw.normalizedLines))
+    record.normalizedLines = raw.normalizedLines;
+  if (raw.createdAt) record.createdAt = raw.createdAt;
+  if (raw.updatedAt) record.updatedAt = raw.updatedAt;
+  return record;
+}
+
+function coerceBibleRecord(raw) {
+  if (!raw) return null;
+  const id = raw.id || raw.name;
+  if (!id) return null;
+  if (Array.isArray(raw.parsedData)) {
+    return {
+      id,
+      name: raw.name || id,
+      parsedData: raw.parsedData,
+      searchableText: raw.searchableText || normalizeSearchText(raw.name || id),
+      createdAt: raw.createdAt || Date.now(),
+      updatedAt: raw.updatedAt || Date.now(),
+    };
+  }
+  if (raw.xmlText) {
+    try {
+      const xml = new DOMParser().parseFromString(raw.xmlText, "text/xml");
+      const parsed = parseBible(xml, raw.name || id);
+      return buildBibleRecord(raw.name || id, parsed, {
+        isNew: false,
+        createdAt: raw.createdAt || null,
+      });
+    } catch (e) {
+      return null;
+    }
+  }
+  return null;
+}
+
+function normalizeSongRecords(raw) {
+  if (Array.isArray(raw)) return raw.map(coerceSongRecord).filter(Boolean);
+  if (raw && typeof raw === "object") {
+    return Object.values(raw).map(coerceSongRecord).filter(Boolean);
+  }
+  return [];
+}
+
+function normalizeBibleRecords(raw) {
+  if (Array.isArray(raw)) return raw.map(coerceBibleRecord).filter(Boolean);
+  if (raw && typeof raw === "object") {
+    const out = [];
+    Object.entries(raw).forEach(([id, value]) => {
+      if (Array.isArray(value)) {
+        out.push(buildBibleRecord(id, value, { isNew: false }));
+      } else if (value && typeof value === "object") {
+        out.push(coerceBibleRecord({ id, ...value }));
+      }
+    });
+    return out.filter(Boolean);
+  }
+  return [];
+}
+
+function safeStringify(value) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (e) {
+    return JSON.stringify(
+      value,
+      (key, val) => {
+        if (typeof val === "function") return undefined;
+        if (val && val.nodeType) return undefined;
+        if (typeof val === "bigint") return val.toString();
+        if (val instanceof Map) return Array.from(val.entries());
+        if (val instanceof Set) return Array.from(val.values());
+        return val;
+      },
+      2,
+    );
+  }
+}
+
+function showObsBackupOverlay(filename, json) {
+  const isObsBrowserSource = !!window.obsstudio;
+  const existing = document.getElementById("obs-backup-overlay");
+  if (existing) existing.remove();
+  const overlay = document.createElement("div");
+  overlay.id = "obs-backup-overlay";
+  overlay.style.cssText =
+    "position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.72);display:flex;align-items:center;justify-content:center;padding:16px;";
+  const panel = document.createElement("div");
+  panel.style.cssText =
+    "width:min(980px,96vw);max-height:92vh;background:#0f1117;border:1px solid rgba(255,255,255,0.16);border-radius:10px;display:flex;flex-direction:column;overflow:hidden;";
+  const header = document.createElement("div");
+  header.style.cssText =
+    "padding:10px 12px;border-bottom:1px solid rgba(255,255,255,0.12);display:flex;align-items:center;gap:8px;color:#e8ecf5;font:600 12px/1.2 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;";
+  header.textContent = t("backup_json_title").replace("{filename}", filename);
+  const btnWrap = document.createElement("div");
+  btnWrap.style.cssText = "margin-left:auto;display:flex;gap:8px;";
+  const btnCopy = document.createElement("button");
+  btnCopy.type = "button";
+  btnCopy.textContent = "Copy";
+  btnCopy.style.cssText =
+    "padding:6px 10px;font-size:11px;border-radius:6px;border:1px solid rgba(255,255,255,0.2);background:#1b2030;color:#fff;cursor:pointer;";
+  const btnSave = document.createElement("button");
+  btnSave.type = "button";
+  btnSave.textContent = "Save .json";
+  btnSave.style.cssText = btnCopy.style.cssText;
+  const btnClose = document.createElement("button");
+  btnClose.type = "button";
+  btnClose.textContent = "Close";
+  btnClose.style.cssText =
+    "padding:6px 10px;font-size:11px;border-radius:6px;border:1px solid rgba(255,255,255,0.2);background:#2a1520;color:#fff;cursor:pointer;";
+  btnWrap.appendChild(btnCopy);
+  btnWrap.appendChild(btnSave);
+  btnWrap.appendChild(btnClose);
+  header.appendChild(btnWrap);
+  const body = document.createElement("div");
+  body.style.cssText =
+    "padding:10px;display:flex;flex-direction:column;gap:8px;";
+  const hint = document.createElement("div");
+  hint.style.cssText =
+    "color:#c7d2ea;font:500 11px/1.3 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;";
+  hint.textContent = isObsBrowserSource
+    ? t("backup_overlay_obs_hint")
+    : t("backup_overlay_save_hint");
+  const ta = document.createElement("textarea");
+  ta.readOnly = true;
+  ta.value = json;
+  ta.style.cssText =
+    "width:100%;height:min(72vh,640px);resize:vertical;background:#080b12;color:#eaf0ff;border:1px solid rgba(255,255,255,0.14);border-radius:8px;padding:10px;font:12px/1.35 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;";
+  body.appendChild(hint);
+  body.appendChild(ta);
+  panel.appendChild(header);
+  panel.appendChild(body);
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+  ta.focus();
+  ta.select();
+
+  const close = () => overlay.remove();
+  btnClose.onclick = close;
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) close();
+  });
+  btnCopy.onclick = async () => {
+    let ok = false;
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(json);
+        ok = true;
+      } catch (_) {}
+    }
+    if (!ok) {
+      try {
+        ta.focus();
+        ta.select();
+        ok = !!document.execCommand("copy");
+      } catch (_) {}
+    }
+    showToast(ok ? "Backup copied to clipboard" : t("common_copy_failed"));
+  };
+  btnSave.onclick = async () => {
+    try {
+      const payload = ta && typeof ta.value === "string" ? ta.value : json;
+      if (typeof window.showSaveFilePicker === "function") {
+        try {
+          const handle = await window.showSaveFilePicker({
+            suggestedName: filename,
+            types: [
+              {
+                description: "JSON Backup",
+                accept: { "application/json": [".json"] },
+              },
+            ],
+          });
+          if (handle && typeof handle.createWritable === "function") {
+            const writable = await handle.createWritable();
+            const encoded = new TextEncoder().encode(payload);
+            await writable.write(encoded);
+            await writable.close();
+            if (typeof handle.getFile === "function") {
+              const savedFile = await handle.getFile();
+              if (!savedFile || !savedFile.size) {
+                throw new Error("Saved file is empty");
+              }
+            }
+            showToast(t("backup_saved"));
+            return;
+          }
+        } catch (pickerErr) {
+          if (
+            pickerErr &&
+            (pickerErr.name === "AbortError" || pickerErr.code === 20)
+          )
+            return;
+          console.warn(
+            "Backup overlay: save picker failed, falling back",
+            pickerErr,
+          );
+        }
+      }
+      let saved = false;
+      try {
+        const dataUrl =
+          "data:application/octet-stream;charset=utf-8," +
+          encodeURIComponent(payload);
+        const link = document.createElement("a");
+        link.href = dataUrl;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        saved = true;
+      } catch (dataErr) {
+        console.warn("Backup overlay: data URI download failed", dataErr);
+      }
+      if (!saved) {
+        try {
+          const blob = new Blob([payload], { type: "application/json" });
           const url = URL.createObjectURL(blob);
-          const link = document.createElement('a');
+          const link = document.createElement("a");
           link.href = url;
           link.download = filename;
           document.body.appendChild(link);
           link.click();
           link.remove();
-          setTimeout(() => URL.revokeObjectURL(url), 400);
-          downloadSucceeded = true;
-        } catch (err) {
-          console.error('Backup export: blob download failed', err);
+          setTimeout(() => URL.revokeObjectURL(url), 30000);
+          saved = true;
+        } catch (blobErr) {
+          console.warn("Backup overlay: blob download failed", blobErr);
         }
-        if (!downloadSucceeded) {
+      }
+      if (saved) {
+        showToast(t("backup_save_triggered_downloads"));
+      } else {
+        let copied = false;
+        if (navigator.clipboard?.writeText) {
           try {
-            const dataUrl = `data:application/json;charset=utf-8,${encodeURIComponent(json)}`;
-            const link = document.createElement('a');
-            link.href = dataUrl;
-            link.download = filename;
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
-            downloadSucceeded = true;
-          } catch (err) {
-            console.error('Backup export: data URL fallback failed', err);
+            await navigator.clipboard.writeText(payload);
+            copied = true;
+          } catch (_) {}
+        }
+        showToast(
+          copied
+            ? t("backup_save_failed_clipboard_fallback")
+            : t("backup_save_failed"),
+        );
+      }
+    } catch (_) {
+      showToast(t("backup_save_failed"));
+    }
+  };
+}
+
+async function exportBackup() {
+  try {
+    const filename = formatBackupFilename(new Date());
+    let saveHandle = null;
+    const isObsBrowserSource = !!(
+      window.obsstudio &&
+      !(
+        window.BSPDesktop &&
+        typeof window.BSPDesktop.saveRecordingFile === "function"
+      )
+    );
+    if (typeof window.showSaveFilePicker === "function") {
+      try {
+        saveHandle = await window.showSaveFilePicker({
+          suggestedName: filename,
+          types: [
+            {
+              description: "JSON Backup",
+              accept: { "application/json": [".json"] },
+            },
+          ],
+        });
+      } catch (pickErr) {
+        // User-cancel should not show a failure toast.
+        if (pickErr && (pickErr.name === "AbortError" || pickErr.code === 20))
+          return;
+        console.warn(
+          "Backup export: save picker unavailable/fallback",
+          pickErr,
+        );
+      }
+    }
+    let dbOk = true;
+    await openDb().catch((err) => {
+      console.error("Backup export: openDb failed", err);
+      dbPromise = null;
+      dbOk = false;
+    });
+    let songRecords = [];
+    let bibleRecords = [];
+    let stateEntry = null;
+    if (dbOk) {
+      try {
+        const results = await Promise.all([
+          dbGetAll(STORE_SONGS),
+          dbGetAll(STORE_BIBLES),
+          idbGet(STORE_STATE, "appState"),
+        ]);
+        songRecords = results[0] || [];
+        bibleRecords = results[1] || [];
+        stateEntry = results[2] || null;
+      } catch (e) {
+        console.error("Backup export: IndexedDB read failed", e);
+        dbOk = false;
+      }
+    }
+    if (!dbOk) {
+      console.warn("Backup export: falling back to in-memory data");
+    }
+    if (!songRecords.length && songs.length) {
+      songRecords = songs.map(coerceSongRecord).filter(Boolean);
+    }
+    if (!bibleRecords.length && Object.keys(bibles).length) {
+      bibleRecords = Object.keys(bibles)
+        .map((name) =>
+          buildBibleRecord(name, bibles[name] || [], { isNew: false }),
+        )
+        .filter(Boolean);
+    }
+    if (stateReady && appState) {
+      syncAppStateFromUi();
+    }
+    const stateValue =
+      appState ||
+      (stateEntry && stateEntry.value
+        ? stateEntry.value
+        : buildDefaultAppState());
+    const settings =
+      stateValue.settings && typeof stateValue.settings === "object"
+        ? stateValue.settings
+        : {};
+    if (bgUploadDataUrl != null) settings.bgUploadDataUrl = bgUploadDataUrl;
+    if (bgVideoUploadDataUrl != null)
+      settings.bgVideoUploadDataUrl = bgVideoUploadDataUrl;
+    const backup = {
+      app: "Bible Song Pro",
+      backupVersion: 1,
+      exportedAt: new Date().toISOString(),
+      data: {
+        songs: songRecords,
+        bibles: bibleRecords,
+        appState: stateValue,
+        settings,
+        ltStyles: settings.ltStyles || ltStyles,
+        customFonts: settings.customFonts || customFonts,
+        presets: Array.isArray(stateValue.presets)
+          ? stateValue.presets
+          : presets,
+        extra: {
+          backgroundUploads: {
+            bgUploadDataUrl: bgUploadDataUrl || "",
+            bgVideoUploadDataUrl: bgVideoUploadDataUrl || "",
+          },
+        },
+      },
+    };
+    const json = safeStringify(backup);
+    if (!json) throw new Error("Backup stringify failed");
+    if (saveHandle) {
+      try {
+        const writable = await saveHandle.createWritable();
+        const encoded = new TextEncoder().encode(json);
+        await writable.write(encoded);
+        await writable.close();
+        if (typeof saveHandle.getFile === "function") {
+          const savedFile = await saveHandle.getFile();
+          if (!savedFile || !savedFile.size) {
+            throw new Error("Saved file is empty");
           }
         }
-        if (!downloadSucceeded && navigator.clipboard?.writeText) {
-          await navigator.clipboard.writeText(json).catch(() => {});
-          showToast(t('backup_export_fallback_clipboard'));
-          return;
-        }
-        if (!downloadSucceeded) throw new Error('Backup download failed');
-        showToast(t('backup_exported_named').replace('{filename}', filename));
-      } catch (e) {
-        console.error('Backup export failed', e);
-        showToast(t('backup_export_failed'));
+        showToast(t("backup_exported"));
+        return;
+      } catch (saveErr) {
+        console.error(
+          "Backup export: save picker write failed, falling back",
+          saveErr,
+        );
       }
     }
-
-    function triggerBackupImport() {
-      const input = document.getElementById('backup-import-file');
-      if (input) input.click();
+    if (isObsBrowserSource) {
+      let copied = false;
+      if (navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(json);
+          copied = true;
+        } catch (clipErr) {
+          console.error(
+            "Backup export: OBS clipboard fallback failed",
+            clipErr,
+          );
+        }
+      }
+      showObsBackupOverlay(filename, json);
+      if (copied) {
+        showToast(t("backup_ready_viewer_opened_copied"));
+        return;
+      }
+      showToast(t("backup_ready_viewer_opened"));
+      return;
     }
 
-    async function handleBackupImport(input) {
-      const file = input.files && input.files[0];
-      input.value = '';
-      if (!file) return;
+    let downloadSucceeded = false;
+    try {
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 400);
+      downloadSucceeded = true;
+    } catch (err) {
+      console.error("Backup export: blob download failed", err);
+    }
+    if (!downloadSucceeded) {
       try {
-        const text = await file.text();
-        const parsed = JSON.parse(text);
-        if (!parsed || parsed.app !== 'Bible Song Pro') {
-          showToast(t('backup_invalid_file'));
-          return;
-        }
-        if (parsed.backupVersion && parsed.backupVersion > 1) {
-          showToast(t('backup_unsupported_version'));
-          return;
-        }
-        pendingBackupData = parsed;
-        showConfirm(t('settings_backup_import'), t('backup_import_overwrite_confirm'), (ok) => {
-          if (!ok) return;
-          applyBackupImport(pendingBackupData);
-        });
-      } catch (e) {
-        showToast(t('backup_invalid_file'));
+        const dataUrl = `data:application/json;charset=utf-8,${encodeURIComponent(json)}`;
+        const link = document.createElement("a");
+        link.href = dataUrl;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        downloadSucceeded = true;
+      } catch (err) {
+        console.error("Backup export: data URL fallback failed", err);
       }
     }
-
-    async function applyBackupImport(backup) {
-      const data = backup && backup.data ? backup.data : {};
-      const songRecords = normalizeSongRecords(data.songs);
-      const bibleRecords = normalizeBibleRecords(data.bibles);
-      const mergedState = mergeAppStateWithDefaults(data.appState);
-      const settings = (mergedState.settings && typeof mergedState.settings === 'object') ? { ...mergedState.settings } : {};
-      if (data.settings && typeof data.settings === 'object') Object.assign(settings, data.settings);
-      if (data.ltStyles && typeof data.ltStyles === 'object') settings.ltStyles = data.ltStyles;
-      if (Array.isArray(data.customFonts)) settings.customFonts = data.customFonts;
-      if (data.extra && data.extra.backgroundUploads) {
-        const uploads = data.extra.backgroundUploads || {};
-        if (uploads.bgUploadDataUrl != null) settings.bgUploadDataUrl = uploads.bgUploadDataUrl;
-        if (uploads.bgVideoUploadDataUrl != null) settings.bgVideoUploadDataUrl = uploads.bgVideoUploadDataUrl;
-      }
-      if (Object.keys(settings).length) mergedState.settings = settings;
-      if (Array.isArray(data.presets)) mergedState.presets = data.presets;
-      const bgSnapshot = extractBackgroundSnapshot(mergedState.settings);
-      const animationSnapshot = extractAnimationSnapshot(mergedState.settings);
-      const typographySnapshot = extractTypographySnapshot(mergedState.settings);
-      const modeSnapshot = extractModeSettingsSnapshot(mergedState.settings);
-
-      isRestoringBackup = true;
-      stateReady = false;
-      try {
-        ltStyles = {};
-        customFonts = [];
-        loadedFontNames.clear();
-        await openDb();
-        await Promise.all([
-          dbClearStore(STORE_SONGS),
-          dbClearStore(STORE_BIBLES),
-          dbClearStore(STORE_STATE)
-        ]);
-        await Promise.all([
-          dbPutMany(STORE_SONGS, songRecords),
-          dbPutMany(STORE_BIBLES, bibleRecords),
-          dbSetAppState(mergedState),
-          (mergedState.settings && mergedState.settings.ltStyles) ? idbPut(STORE_STATE, { key: 'ltStyles', value: mergedState.settings.ltStyles, updatedAt: Date.now() }) : Promise.resolve(true),
-          bgSnapshot ? idbPut(STORE_STATE, { key: 'bgSettings', value: bgSnapshot, updatedAt: Date.now() }) : Promise.resolve(true),
-          animationSnapshot ? idbPut(STORE_STATE, { key: 'animationSettings', value: animationSnapshot, updatedAt: Date.now() }) : Promise.resolve(true),
-          typographySnapshot ? idbPut(STORE_STATE, { key: 'typographySettings', value: typographySnapshot, updatedAt: Date.now() }) : Promise.resolve(true),
-          modeSnapshot ? idbPut(STORE_STATE, { key: 'modeSettings', value: modeSnapshot, updatedAt: Date.now() }) : Promise.resolve(true)
-        ]);
-
-        applyLoadedState(mergedState, songRecords, bibleRecords, { runInit: false });
-        stateReady = true;
-        saveState();
-        if (pendingPersist) {
-          pendingPersist = false;
-          saveToStorage();
-        }
-        if (pendingBgPersist) {
-          pendingBgPersist = false;
-          persistBackgroundState();
-        }
-        if (pendingAnimationPersist) {
-          pendingAnimationPersist = false;
-          persistAnimationState();
-        }
-        if (pendingTypographyPersist) {
-          pendingTypographyPersist = false;
-          persistTypographyState();
-        }
-        if (pendingModePersist) {
-          pendingModePersist = false;
-          persistModeSettings();
-        }
-        sendSyncState();
-        showToast(t('backup_imported_successfully'));
-      } catch (e) {
-        showToast(t('backup_import_failed'));
-      } finally {
-        isRestoringBackup = false;
-      }
+    if (!downloadSucceeded && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(json).catch(() => {});
+      showToast(t("backup_export_fallback_clipboard"));
+      return;
     }
+    if (!downloadSucceeded) throw new Error("Backup download failed");
+    showToast(t("backup_exported_named").replace("{filename}", filename));
+  } catch (e) {
+    console.error("Backup export failed", e);
+    showToast(t("backup_export_failed"));
+  }
+}
 
-    function detectBibleLanguage(xml, verName) {
-      const root = xml.querySelector('bible') || xml.querySelector('XMLBIBLE') || xml.querySelector('xmlbible');
-      const hintRaw = (root?.getAttribute('translation') || root?.getAttribute('language') || root?.getAttribute('lang') || root?.getAttribute('biblename') || verName || "").toLowerCase();
-      const langTests = [
-        { key: 'afrikaans', patterns: ['afrikaans', 'afr '] },
-        { key: 'arabic', patterns: ['arabic', 'عرب', 'عربي'] },
-        { key: 'albanian', patterns: ['albanian', 'shqip'] },
-        { key: 'armenian', patterns: ['armenian', 'հայ'] },
-        { key: 'amharic', patterns: ['amharic', 'አማርኛ'] },
-        { key: 'azerbaijani', patterns: ['azerbaijani', 'azerbaijan', 'azeri', 'azərbaycan'] },
-        { key: 'basque', patterns: ['basque', 'euskara', 'euskera'] },
-        { key: 'bengali', patterns: ['bengali', 'bangla', 'বাংলা'] },
-        { key: 'bulgarian', patterns: ['bulgarian', 'български'] },
-        { key: 'burmese', patterns: ['burmese', 'myanmar', 'မြန်မာ'] },
-        { key: 'catalan', patterns: ['catalan', 'català'] },
-        { key: 'cebuano', patterns: ['cebuano', 'bisaya', 'binisaya'] },
-        { key: 'chechen', patterns: ['chechen', 'чечен', 'нохч'] },
-        { key: 'chewa', patterns: ['chewa', 'chichewa', 'nyanja'] },
-        { key: 'chhattisgarhi', patterns: ['chhattisgarhi', 'chattisgarhi', 'छत्तीसगढ़ी'] },
-        { key: 'chinese_traditional', patterns: ['traditional chinese', '繁體', '繁体', 'zh-tw', 'zh_tw', 'zh-hk', 'zh_hk'] },
-        { key: 'chinese', patterns: ['chinese', '中文', '简体', 'simplified', 'zh-cn', 'zh_cn'] },
-        { key: 'chuvash', patterns: ['chuvash', 'чуваш'] },
-        { key: 'croatian', patterns: ['croatian', 'hrvatski'] },
-        { key: 'czech', patterns: ['czech', 'čeština', 'cesky'] },
-        { key: 'danish', patterns: ['danish', 'dansk'] },
-        { key: 'dinka', patterns: ['dinka'] },
-        { key: 'dutch', patterns: ['dutch', 'nederlands'] },
-        { key: 'ewe', patterns: ['ewe'] },
-        { key: 'esperanto', patterns: ['esperanto'] },
-        { key: 'estonian', patterns: ['estonian', 'eesti'] },
-        { key: 'finnish', patterns: ['finnish', 'suomi'] },
-        { key: 'bavarian', patterns: ['bavarian', 'bairisch'] },
-        { key: 'belarusian', patterns: ['belarusian', 'беларуск'] },
-        { key: 'bemba', patterns: ['bemba'] },
-        { key: 'berber', patterns: ['berber', 'amazigh', 'tamazight'] },
-        { key: 'bhilali', patterns: ['bhilali'] },
-        { key: 'bundeli', patterns: ['bundeli', 'बुंदेली', 'बुन्देली'] },
-        { key: 'bodo', patterns: ['bodo'] },
-        { key: 'coptic', patterns: ['coptic', 'copte'] },
-        { key: 'dagbani', patterns: ['dagbani'] },
-        { key: 'bosnian', patterns: ['bosnian', 'bosanski'] },
-        { key: 'braj', patterns: ['braj'] },
-        { key: 'bugis', patterns: ['bugis', 'buginese'] },
-        { key: 'fon', patterns: ['fon'] },
-        { key: 'fulfulde', patterns: ['fulfulde', 'fufulde', 'fulani'] },
-        { key: 'gaelic', patterns: ['gaelic', 'gàidhlig', 'gaeilge'] },
-        { key: 'galician', patterns: ['galician', 'galego'] },
-        { key: 'garhwali', patterns: ['garhwali'] },
-        { key: 'georgian', patterns: ['georgian', 'ქართული'] },
-        { key: 'german', patterns: ['german', 'deutsch'] },
-        { key: 'ghomala', patterns: ['ghomala'] },
-        { key: 'greek', patterns: ['greek', 'ελλην'] },
-        { key: 'guarani', patterns: ['guarani'] },
-        { key: 'gujarati', patterns: ['gujarati', 'ગુજરાતી'] },
-        { key: 'gussi', patterns: ['gussi'] },
-        { key: 'hadiyya', patterns: ['hadiyya'] },
-        { key: 'haitian', patterns: ['haitian', 'kreyol', 'créole', 'creole'] },
-        { key: 'haryanvi', patterns: ['haryanvi', 'हरियाणवी'] },
-        { key: 'hausa', patterns: ['hausa'] },
-        { key: 'hebrew', patterns: ['hebrew', 'עברית'] },
-        { key: 'ika', patterns: ['ika'] },
-        { key: 'ilokano', patterns: ['ilokano', 'ilocano'] },
-        { key: 'ilonggo', patterns: ['ilonggo', 'hiligaynon'] },
-        { key: 'indonesian', patterns: ['indonesian', 'bahasa indonesia'] },
-        { key: 'irish', patterns: ['irish', 'gaeilge'] },
-        { key: 'italian', patterns: ['italian', 'italiano'] },
-        { key: 'dogri', patterns: ['dogri', 'डोगरी'] },
-        { key: 'dyula', patterns: ['dyula', 'jula'] },
-        { key: 'edo', patterns: ['edo', 'bini'] },
-        { key: 'hmong', patterns: ['hmong'] },
-        { key: 'hungarian', patterns: ['hungarian', 'magyar'] },
-        { key: 'iban', patterns: ['iban'] },
-        { key: 'ibibio', patterns: ['ibibio'] },
-        { key: 'icelandic', patterns: ['icelandic', 'íslenska'] },
-        { key: 'igbo', patterns: ['igbo'] },
-        { key: 'ika', patterns: ['ika'] },
-        { key: 'ilokano', patterns: ['ilokano', 'ilocano'] },
-        { key: 'ilonggo', patterns: ['ilonggo', 'hiligaynon'] },
-        { key: 'indonesian', patterns: ['indonesian', 'bahasa indonesia'] },
-        { key: 'irish', patterns: ['irish', 'gaeilge'] },
-        { key: 'italian', patterns: ['italian', 'italiano'] },
-        { key: 'iu_mien', patterns: ['iu mien', 'iumien', 'mien'] },
-        { key: 'jamaican', patterns: ['jamaican'] },
-        { key: 'japanese', patterns: ['japanese', '日本語', '日本'] },
-        { key: 'javanese', patterns: ['javanese', 'jawa'] },
-        { key: 'kabardian', patterns: ['kabardian'] },
-        { key: 'kabyle', patterns: ['kabyle', 'taqbaylit'] },
-        { key: 'kachin', patterns: ['kachin'] },
-        { key: 'kalenjin', patterns: ['kalenjin'] },
-        { key: 'kamba', patterns: ['kamba'] },
-        { key: 'kangri', patterns: ['kangri'] },
-        { key: 'kannada', patterns: ['kannada', 'ಕನ್ನಡ'] },
-        { key: 'karakalpak', patterns: ['karakalpak'] },
-        { key: 'kazakh', patterns: ['kazakh', 'қазақ'] },
-        { key: 'kiche', patterns: ["k\\'iche", 'kiche'] },
-        { key: 'kikuyu', patterns: ['kikuyu'] },
-        { key: 'kikwango', patterns: ['kikwango'] },
-        { key: 'kimbundu', patterns: ['kimbundu'] },
-        { key: 'kimiiru', patterns: ['kimiiru'] },
-        { key: 'kinyarwanda', patterns: ['kinyarwanda'] },
-        { key: 'kirundi', patterns: ['kirundi'] },
-        { key: 'kituba', patterns: ['kituba'] },
-        { key: 'konkani', patterns: ['konkani', 'कोंकणी', 'ಕೋಂಕಣಿ'] },
-        { key: 'korean', patterns: ['korean', '한국어', '조선어'] },
-        { key: 'koya', patterns: ['koya'] },
-        { key: 'krio', patterns: ['krio'] },
-        { key: 'kumaoni', patterns: ['kumaoni'] },
-        { key: 'kurdish', patterns: ['kurdish', 'kurdî'] },
-        { key: 'kurukh', patterns: ['kurukh'] },
-        { key: 'kyrgyz', patterns: ['kyrgyz', 'кыргыз'] },
-        { key: 'khmer', patterns: ['khmer', 'ភាសាខ្មែរ'] },
-        { key: 'lahu', patterns: ['lahu'] },
-        { key: 'lambadi', patterns: ['lambadi'] },
-        { key: 'lango', patterns: ['lango'] },
-        { key: 'lao', patterns: ['lao', 'ລາວ'] },
-        { key: 'latin', patterns: ['latin', 'latina', 'vulgate'] },
-        { key: 'latvian', patterns: ['latvian', 'latviešu', 'latviesu'] },
-        { key: 'liberian_kreyol', patterns: ['liberian kreyol', 'liberian', 'liberia'] },
-        { key: 'lingala', patterns: ['lingala'] },
-        { key: 'lithuanian', patterns: ['lithuanian', 'lietuvi', 'lietuvių', 'lietuviu'] },
-        { key: 'lomwe', patterns: ['lomwe'] },
-        { key: 'luganda', patterns: ['luganda'] },
-        { key: 'lugbara', patterns: ['lugbara'] },
-        { key: 'luguru', patterns: ['luguru'] },
-        { key: 'luo', patterns: ['luo'] },
-        { key: 'maasai', patterns: ['maasai'] },
-        { key: 'macedonian', patterns: ['macedonian', 'македон'] },
-        { key: 'madurese', patterns: ['madurese'] },
-        { key: 'maithili', patterns: ['maithili'] },
-        { key: 'makhuwa', patterns: ['makhuwa'] },
-        { key: 'makonde', patterns: ['makonde'] },
-        { key: 'malagasy', patterns: ['malagasy'] },
-        { key: 'malayalam', patterns: ['malayalam', 'മലയാളം'] },
-        { key: 'malaysian', patterns: ['malaysian', 'bahasa melayu', 'malay'] },
-        { key: 'maori', patterns: ['maori', 'māori'] },
-        { key: 'marathi', patterns: ['marathi', 'मराठी'] },
-        { key: 'marwari', patterns: ['marwari', 'मारवाड़ी', 'मारवाड़ी'] },
-        { key: 'marshallese', patterns: ['marshallese'] },
-        { key: 'mauritian_creole', patterns: ['mauritian creole', 'mauritian', 'morisyen'] },
-        { key: 'mazanderani', patterns: ['mazanderani', 'mazandarani', 'مازندرانی'] },
-        { key: 'meitei', patterns: ['meitei', 'manipuri'] },
-        { key: 'mende', patterns: ['mende'] },
-        { key: 'meru', patterns: ['meru'] },
-        { key: 'msl', patterns: ['msl'] },
-        { key: 'minangkabau', patterns: ['minangkabau'] },
-        { key: 'miskito', patterns: ['miskito'] },
-        { key: 'mixtec', patterns: ['mixtec'] },
-        { key: 'moore', patterns: ['moore', 'moré', 'more'] },
-        { key: 'more', patterns: ['moré', 'more'] },
-        { key: 'mortlockese', patterns: ['mortlockese'] },
-        { key: 'motu', patterns: ['motu'] },
-        { key: 'mundari', patterns: ['mundari'] },
-        { key: 'mushunguli', patterns: ['mushunguli'] },
-        { key: 'myanmar', patterns: ['myanmar'] },
-        { key: 'nama', patterns: ['nama'] },
-        { key: 'nauruan', patterns: ['nauruan', 'nauru'] },
-        { key: 'ndau', patterns: ['ndau'] },
-        { key: 'ndonga', patterns: ['ndonga'] },
-        { key: 'nepali', patterns: ['nepali', 'नेपाली'] },
-        { key: 'ngambay', patterns: ['ngambay'] },
-        { key: 'nigerian_pidgin', patterns: ['nigerian pidgin', 'pidgin'] },
-        { key: 'niuean', patterns: ['niuean'] },
-        { key: 'northern_sotho', patterns: ['northern sotho', 'sepedi', 'sesotho sa lebowa'] },
-        { key: 'norwegian', patterns: ['norwegian', 'norsk'] },
-        { key: 'nyanja', patterns: ['nyanja'] },
-        { key: 'nyankore', patterns: ['nyankore'] },
-        { key: 'nyoro', patterns: ['nyoro'] },
-        { key: 'occitan', patterns: ['occitan'] },
-        { key: 'odia', patterns: ['odia', 'oriya', 'ଓଡିଆ'] },
-        { key: 'oromo', patterns: ['oromo', 'afaan oromo'] },
-        { key: 'ossetian', patterns: ['ossetian', 'ossetic'] },
-        { key: 'pangasinan', patterns: ['pangasinan'] },
-        { key: 'papiamento', patterns: ['papiamento'] },
-        { key: 'pashto', patterns: ['pashto', 'پشتو'] },
-        { key: 'pedi', patterns: ['pedi'] },
-        { key: 'persian', patterns: ['persian', 'farsi', 'فارسی'] },
-        { key: 'polish', patterns: ['polish', 'polski'] },
-        { key: 'portuguese', patterns: ['portuguese', 'português', 'portugues'] },
-        { key: 'punjabi', patterns: ['punjabi', 'ਪੰਜਾਬੀ'] },
-        { key: 'quechua', patterns: ['quechua'] },
-        { key: 'romanian', patterns: ['romanian', 'română', 'romana'] },
-        { key: 'romansh', patterns: ['romansh', 'rumantsch'] },
-        { key: 'romany', patterns: ['romany', 'roma'] },
-        { key: 'russian', patterns: ['russian', 'русский'] },
-        { key: 'samoan', patterns: ['samoan'] },
-        { key: 'sango', patterns: ['sango'] },
-        { key: 'sanskrit', patterns: ['sanskrit', 'संस्कृत'] },
-        { key: 'santali', patterns: ['santali'] },
-        { key: 'scots_gaelic', patterns: ['scots gaelic', 'gàidhlig', 'gaidhlig'] },
-        { key: 'serbian', patterns: ['serbian', 'српски'] },
-        { key: 'sesotho', patterns: ['sesotho', 'sotho'] },
-        { key: 'shona', patterns: ['shona'] },
-        { key: 'sindhi', patterns: ['sindhi', 'सिन्धी', 'سنڌي'] },
-        { key: 'sinhala', patterns: ['sinhala', 'sinhalese', 'සිංහල'] },
-        { key: 'slovak', patterns: ['slovak', 'slovenčina', 'slovencina'] },
-        { key: 'slovenian', patterns: ['slovenian', 'slovenski'] },
-        { key: 'somali', patterns: ['somali', 'somalia'] },
-        { key: 'southern_sotho', patterns: ['southern sotho'] },
-        { key: 'spanish', patterns: ['spanish', 'español', 'espanol'] },
-        { key: 'sundanese', patterns: ['sundanese'] },
-        { key: 'swahili', patterns: ['swahili', 'kiswahili'] },
-        { key: 'swati', patterns: ['swati', 'siswati'] },
-        { key: 'swedish', patterns: ['swedish', 'svenska'] },
-        { key: 'tagalog', patterns: ['tagalog', 'filipino'] },
-        { key: 'tahitian', patterns: ['tahitian'] },
-        { key: 'tajik', patterns: ['tajik', 'тоҷик'] },
-        { key: 'tamazight', patterns: ['tamazight', 'amazigh'] },
-        { key: 'tamil', patterns: ['tamil', 'தமிழ்'] },
-        { key: 'tatar', patterns: ['tatar'] },
-        { key: 'telugu', patterns: ['telugu', 'తెలుగు'] },
-        { key: 'tetum', patterns: ['tetum'] },
-        { key: 'thai', patterns: ['thai', 'ไทย'] },
-        { key: 'tibetan', patterns: ['tibetan', 'བོད་ཡིག'] },
-        { key: 'tigrinya', patterns: ['tigrinya', 'ትግርኛ'] },
-        { key: 'tiv', patterns: ['tiv'] },
-        { key: 'tok_pisin', patterns: ['tok pisin'] },
-        { key: 'tongan', patterns: ['tongan'] },
-        { key: 'tsonga', patterns: ['tsonga'] },
-        { key: 'tswana', patterns: ['tswana'] },
-        { key: 'tumbuka', patterns: ['tumbuka'] },
-        { key: 'turkish', patterns: ['turkish', 'türkçe', 'turkce'] },
-        { key: 'turkmen', patterns: ['turkmen'] },
-        { key: 'tuvaluan', patterns: ['tuvaluan'] },
-        { key: 'twi', patterns: ['twi'] },
-        { key: 'ukrainian', patterns: ['ukrainian', 'україн'] },
-        { key: 'umbundu', patterns: ['umbundu'] },
-        { key: 'urdu', patterns: ['urdu', 'اردو'] },
-        { key: 'uzbek', patterns: ['uzbek', 'oʻzbek'] },
-        { key: 'vietnamese', patterns: ['vietnamese', 'tiếng việt', 'tieng viet'] },
-        { key: 'waray', patterns: ['waray'] },
-        { key: 'welsh', patterns: ['welsh', 'cymraeg'] },
-        { key: 'wolof', patterns: ['wolof'] },
-        { key: 'xhosa', patterns: ['xhosa'] },
-        { key: 'yiddish', patterns: ['yiddish', 'ייִדיש'] },
-        { key: 'yoruba', patterns: ['yoruba'] },
-        { key: 'zulu', patterns: ['zulu', 'isizulu'] },
-        { key: 'fr', patterns: ['french', 'français', 'francais', 'fr '] },
-        { key: 'hi', patterns: ['hindi', 'हिंदी', 'हिन्दी'] }
+function triggerBackupImport() {
+  const input = document.getElementById("backup-import-file");
+  if (input) input.click();
+}
+
+async function handleBackupImport(input) {
+  const file = input.files && input.files[0];
+  input.value = "";
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+    if (!parsed || parsed.app !== "Bible Song Pro") {
+      showToast(t("backup_invalid_file"));
+      return;
+    }
+    if (parsed.backupVersion && parsed.backupVersion > 1) {
+      showToast(t("backup_unsupported_version"));
+      return;
+    }
+    pendingBackupData = parsed;
+    showConfirm(
+      t("settings_backup_import"),
+      t("backup_import_overwrite_confirm"),
+      (ok) => {
+        if (!ok) return;
+        applyBackupImport(pendingBackupData);
+      },
+    );
+  } catch (e) {
+    showToast(t("backup_invalid_file"));
+  }
+}
+
+async function applyBackupImport(backup) {
+  const data = backup && backup.data ? backup.data : {};
+  const songRecords = normalizeSongRecords(data.songs);
+  const bibleRecords = normalizeBibleRecords(data.bibles);
+  const mergedState = mergeAppStateWithDefaults(data.appState);
+  const settings =
+    mergedState.settings && typeof mergedState.settings === "object"
+      ? { ...mergedState.settings }
+      : {};
+  if (data.settings && typeof data.settings === "object")
+    Object.assign(settings, data.settings);
+  if (data.ltStyles && typeof data.ltStyles === "object")
+    settings.ltStyles = data.ltStyles;
+  if (Array.isArray(data.customFonts)) settings.customFonts = data.customFonts;
+  if (data.extra && data.extra.backgroundUploads) {
+    const uploads = data.extra.backgroundUploads || {};
+    if (uploads.bgUploadDataUrl != null)
+      settings.bgUploadDataUrl = uploads.bgUploadDataUrl;
+    if (uploads.bgVideoUploadDataUrl != null)
+      settings.bgVideoUploadDataUrl = uploads.bgVideoUploadDataUrl;
+  }
+  if (Object.keys(settings).length) mergedState.settings = settings;
+  if (Array.isArray(data.presets)) mergedState.presets = data.presets;
+  const bgSnapshot = extractBackgroundSnapshot(mergedState.settings);
+  const animationSnapshot = extractAnimationSnapshot(mergedState.settings);
+  const typographySnapshot = extractTypographySnapshot(mergedState.settings);
+  const modeSnapshot = extractModeSettingsSnapshot(mergedState.settings);
+
+  isRestoringBackup = true;
+  stateReady = false;
+  try {
+    ltStyles = {};
+    customFonts = [];
+    loadedFontNames.clear();
+    await openDb();
+    await Promise.all([
+      dbClearStore(STORE_SONGS),
+      dbClearStore(STORE_BIBLES),
+      dbClearStore(STORE_STATE),
+    ]);
+    await Promise.all([
+      dbPutMany(STORE_SONGS, songRecords),
+      dbPutMany(STORE_BIBLES, bibleRecords),
+      dbSetAppState(mergedState),
+      mergedState.settings && mergedState.settings.ltStyles
+        ? idbPut(STORE_STATE, {
+            key: "ltStyles",
+            value: mergedState.settings.ltStyles,
+            updatedAt: Date.now(),
+          })
+        : Promise.resolve(true),
+      bgSnapshot
+        ? idbPut(STORE_STATE, {
+            key: "bgSettings",
+            value: bgSnapshot,
+            updatedAt: Date.now(),
+          })
+        : Promise.resolve(true),
+      animationSnapshot
+        ? idbPut(STORE_STATE, {
+            key: "animationSettings",
+            value: animationSnapshot,
+            updatedAt: Date.now(),
+          })
+        : Promise.resolve(true),
+      typographySnapshot
+        ? idbPut(STORE_STATE, {
+            key: "typographySettings",
+            value: typographySnapshot,
+            updatedAt: Date.now(),
+          })
+        : Promise.resolve(true),
+      modeSnapshot
+        ? idbPut(STORE_STATE, {
+            key: "modeSettings",
+            value: modeSnapshot,
+            updatedAt: Date.now(),
+          })
+        : Promise.resolve(true),
+    ]);
+
+    applyLoadedState(mergedState, songRecords, bibleRecords, {
+      runInit: false,
+    });
+    stateReady = true;
+    saveState();
+    if (pendingPersist) {
+      pendingPersist = false;
+      saveToStorage();
+    }
+    if (pendingBgPersist) {
+      pendingBgPersist = false;
+      persistBackgroundState();
+    }
+    if (pendingAnimationPersist) {
+      pendingAnimationPersist = false;
+      persistAnimationState();
+    }
+    if (pendingTypographyPersist) {
+      pendingTypographyPersist = false;
+      persistTypographyState();
+    }
+    if (pendingModePersist) {
+      pendingModePersist = false;
+      persistModeSettings();
+    }
+    sendSyncState();
+    showToast(t("backup_imported_successfully"));
+  } catch (e) {
+    showToast(t("backup_import_failed"));
+  } finally {
+    isRestoringBackup = false;
+  }
+}
+
+function detectBibleLanguage(xml, verName) {
+  const root =
+    xml.querySelector("bible") ||
+    xml.querySelector("XMLBIBLE") ||
+    xml.querySelector("xmlbible");
+  const hintRaw = (
+    root?.getAttribute("translation") ||
+    root?.getAttribute("language") ||
+    root?.getAttribute("lang") ||
+    root?.getAttribute("biblename") ||
+    verName ||
+    ""
+  ).toLowerCase();
+  const langTests = [
+    { key: "afrikaans", patterns: ["afrikaans", "afr "] },
+    { key: "arabic", patterns: ["arabic", "عرب", "عربي"] },
+    { key: "albanian", patterns: ["albanian", "shqip"] },
+    { key: "armenian", patterns: ["armenian", "հայ"] },
+    { key: "amharic", patterns: ["amharic", "አማርኛ"] },
+    {
+      key: "azerbaijani",
+      patterns: ["azerbaijani", "azerbaijan", "azeri", "azərbaycan"],
+    },
+    { key: "basque", patterns: ["basque", "euskara", "euskera"] },
+    { key: "bengali", patterns: ["bengali", "bangla", "বাংলা"] },
+    { key: "bulgarian", patterns: ["bulgarian", "български"] },
+    { key: "burmese", patterns: ["burmese", "myanmar", "မြန်မာ"] },
+    { key: "catalan", patterns: ["catalan", "català"] },
+    { key: "cebuano", patterns: ["cebuano", "bisaya", "binisaya"] },
+    { key: "chechen", patterns: ["chechen", "чечен", "нохч"] },
+    { key: "chewa", patterns: ["chewa", "chichewa", "nyanja"] },
+    {
+      key: "chhattisgarhi",
+      patterns: ["chhattisgarhi", "chattisgarhi", "छत्तीसगढ़ी"],
+    },
+    {
+      key: "chinese_traditional",
+      patterns: [
+        "traditional chinese",
+        "繁體",
+        "繁体",
+        "zh-tw",
+        "zh_tw",
+        "zh-hk",
+        "zh_hk",
+      ],
+    },
+    {
+      key: "chinese",
+      patterns: ["chinese", "中文", "简体", "simplified", "zh-cn", "zh_cn"],
+    },
+    { key: "chuvash", patterns: ["chuvash", "чуваш"] },
+    { key: "croatian", patterns: ["croatian", "hrvatski"] },
+    { key: "czech", patterns: ["czech", "čeština", "cesky"] },
+    { key: "danish", patterns: ["danish", "dansk"] },
+    { key: "dinka", patterns: ["dinka"] },
+    { key: "dutch", patterns: ["dutch", "nederlands"] },
+    { key: "ewe", patterns: ["ewe"] },
+    { key: "esperanto", patterns: ["esperanto"] },
+    { key: "estonian", patterns: ["estonian", "eesti"] },
+    { key: "finnish", patterns: ["finnish", "suomi"] },
+    { key: "bavarian", patterns: ["bavarian", "bairisch"] },
+    { key: "belarusian", patterns: ["belarusian", "беларуск"] },
+    { key: "bemba", patterns: ["bemba"] },
+    { key: "berber", patterns: ["berber", "amazigh", "tamazight"] },
+    { key: "bhilali", patterns: ["bhilali"] },
+    { key: "bundeli", patterns: ["bundeli", "बुंदेली", "बुन्देली"] },
+    { key: "bodo", patterns: ["bodo"] },
+    { key: "coptic", patterns: ["coptic", "copte"] },
+    { key: "dagbani", patterns: ["dagbani"] },
+    { key: "bosnian", patterns: ["bosnian", "bosanski"] },
+    { key: "braj", patterns: ["braj"] },
+    { key: "bugis", patterns: ["bugis", "buginese"] },
+    { key: "fon", patterns: ["fon"] },
+    { key: "fulfulde", patterns: ["fulfulde", "fufulde", "fulani"] },
+    { key: "gaelic", patterns: ["gaelic", "gàidhlig", "gaeilge"] },
+    { key: "galician", patterns: ["galician", "galego"] },
+    { key: "garhwali", patterns: ["garhwali"] },
+    { key: "georgian", patterns: ["georgian", "ქართული"] },
+    { key: "german", patterns: ["german", "deutsch"] },
+    { key: "ghomala", patterns: ["ghomala"] },
+    { key: "greek", patterns: ["greek", "ελλην"] },
+    { key: "guarani", patterns: ["guarani"] },
+    { key: "gujarati", patterns: ["gujarati", "ગુજરાતી"] },
+    { key: "gussi", patterns: ["gussi"] },
+    { key: "hadiyya", patterns: ["hadiyya"] },
+    { key: "haitian", patterns: ["haitian", "kreyol", "créole", "creole"] },
+    { key: "haryanvi", patterns: ["haryanvi", "हरियाणवी"] },
+    { key: "hausa", patterns: ["hausa"] },
+    { key: "hebrew", patterns: ["hebrew", "עברית"] },
+    { key: "ika", patterns: ["ika"] },
+    { key: "ilokano", patterns: ["ilokano", "ilocano"] },
+    { key: "ilonggo", patterns: ["ilonggo", "hiligaynon"] },
+    { key: "indonesian", patterns: ["indonesian", "bahasa indonesia"] },
+    { key: "irish", patterns: ["irish", "gaeilge"] },
+    { key: "italian", patterns: ["italian", "italiano"] },
+    { key: "dogri", patterns: ["dogri", "डोगरी"] },
+    { key: "dyula", patterns: ["dyula", "jula"] },
+    { key: "edo", patterns: ["edo", "bini"] },
+    { key: "hmong", patterns: ["hmong"] },
+    { key: "hungarian", patterns: ["hungarian", "magyar"] },
+    { key: "iban", patterns: ["iban"] },
+    { key: "ibibio", patterns: ["ibibio"] },
+    { key: "icelandic", patterns: ["icelandic", "íslenska"] },
+    { key: "igbo", patterns: ["igbo"] },
+    { key: "ika", patterns: ["ika"] },
+    { key: "ilokano", patterns: ["ilokano", "ilocano"] },
+    { key: "ilonggo", patterns: ["ilonggo", "hiligaynon"] },
+    { key: "indonesian", patterns: ["indonesian", "bahasa indonesia"] },
+    { key: "irish", patterns: ["irish", "gaeilge"] },
+    { key: "italian", patterns: ["italian", "italiano"] },
+    { key: "iu_mien", patterns: ["iu mien", "iumien", "mien"] },
+    { key: "jamaican", patterns: ["jamaican"] },
+    { key: "japanese", patterns: ["japanese", "日本語", "日本"] },
+    { key: "javanese", patterns: ["javanese", "jawa"] },
+    { key: "kabardian", patterns: ["kabardian"] },
+    { key: "kabyle", patterns: ["kabyle", "taqbaylit"] },
+    { key: "kachin", patterns: ["kachin"] },
+    { key: "kalenjin", patterns: ["kalenjin"] },
+    { key: "kamba", patterns: ["kamba"] },
+    { key: "kangri", patterns: ["kangri"] },
+    { key: "kannada", patterns: ["kannada", "ಕನ್ನಡ"] },
+    { key: "karakalpak", patterns: ["karakalpak"] },
+    { key: "kazakh", patterns: ["kazakh", "қазақ"] },
+    { key: "kiche", patterns: ["k\\'iche", "kiche"] },
+    { key: "kikuyu", patterns: ["kikuyu"] },
+    { key: "kikwango", patterns: ["kikwango"] },
+    { key: "kimbundu", patterns: ["kimbundu"] },
+    { key: "kimiiru", patterns: ["kimiiru"] },
+    { key: "kinyarwanda", patterns: ["kinyarwanda"] },
+    { key: "kirundi", patterns: ["kirundi"] },
+    { key: "kituba", patterns: ["kituba"] },
+    { key: "konkani", patterns: ["konkani", "कोंकणी", "ಕೋಂಕಣಿ"] },
+    { key: "korean", patterns: ["korean", "한국어", "조선어"] },
+    { key: "koya", patterns: ["koya"] },
+    { key: "krio", patterns: ["krio"] },
+    { key: "kumaoni", patterns: ["kumaoni"] },
+    { key: "kurdish", patterns: ["kurdish", "kurdî"] },
+    { key: "kurukh", patterns: ["kurukh"] },
+    { key: "kyrgyz", patterns: ["kyrgyz", "кыргыз"] },
+    { key: "khmer", patterns: ["khmer", "ភាសាខ្មែរ"] },
+    { key: "lahu", patterns: ["lahu"] },
+    { key: "lambadi", patterns: ["lambadi"] },
+    { key: "lango", patterns: ["lango"] },
+    { key: "lao", patterns: ["lao", "ລາວ"] },
+    { key: "latin", patterns: ["latin", "latina", "vulgate"] },
+    { key: "latvian", patterns: ["latvian", "latviešu", "latviesu"] },
+    {
+      key: "liberian_kreyol",
+      patterns: ["liberian kreyol", "liberian", "liberia"],
+    },
+    { key: "lingala", patterns: ["lingala"] },
+    {
+      key: "lithuanian",
+      patterns: ["lithuanian", "lietuvi", "lietuvių", "lietuviu"],
+    },
+    { key: "lomwe", patterns: ["lomwe"] },
+    { key: "luganda", patterns: ["luganda"] },
+    { key: "lugbara", patterns: ["lugbara"] },
+    { key: "luguru", patterns: ["luguru"] },
+    { key: "luo", patterns: ["luo"] },
+    { key: "maasai", patterns: ["maasai"] },
+    { key: "macedonian", patterns: ["macedonian", "македон"] },
+    { key: "madurese", patterns: ["madurese"] },
+    { key: "maithili", patterns: ["maithili"] },
+    { key: "makhuwa", patterns: ["makhuwa"] },
+    { key: "makonde", patterns: ["makonde"] },
+    { key: "malagasy", patterns: ["malagasy"] },
+    { key: "malayalam", patterns: ["malayalam", "മലയാളം"] },
+    { key: "malaysian", patterns: ["malaysian", "bahasa melayu", "malay"] },
+    { key: "maori", patterns: ["maori", "māori"] },
+    { key: "marathi", patterns: ["marathi", "मराठी"] },
+    { key: "marwari", patterns: ["marwari", "मारवाड़ी", "मारवाड़ी"] },
+    { key: "marshallese", patterns: ["marshallese"] },
+    {
+      key: "mauritian_creole",
+      patterns: ["mauritian creole", "mauritian", "morisyen"],
+    },
+    {
+      key: "mazanderani",
+      patterns: ["mazanderani", "mazandarani", "مازندرانی"],
+    },
+    { key: "meitei", patterns: ["meitei", "manipuri"] },
+    { key: "mende", patterns: ["mende"] },
+    { key: "meru", patterns: ["meru"] },
+    { key: "msl", patterns: ["msl"] },
+    { key: "minangkabau", patterns: ["minangkabau"] },
+    { key: "miskito", patterns: ["miskito"] },
+    { key: "mixtec", patterns: ["mixtec"] },
+    { key: "moore", patterns: ["moore", "moré", "more"] },
+    { key: "more", patterns: ["moré", "more"] },
+    { key: "mortlockese", patterns: ["mortlockese"] },
+    { key: "motu", patterns: ["motu"] },
+    { key: "mundari", patterns: ["mundari"] },
+    { key: "mushunguli", patterns: ["mushunguli"] },
+    { key: "myanmar", patterns: ["myanmar"] },
+    { key: "nama", patterns: ["nama"] },
+    { key: "nauruan", patterns: ["nauruan", "nauru"] },
+    { key: "ndau", patterns: ["ndau"] },
+    { key: "ndonga", patterns: ["ndonga"] },
+    { key: "nepali", patterns: ["nepali", "नेपाली"] },
+    { key: "ngambay", patterns: ["ngambay"] },
+    { key: "nigerian_pidgin", patterns: ["nigerian pidgin", "pidgin"] },
+    { key: "niuean", patterns: ["niuean"] },
+    {
+      key: "northern_sotho",
+      patterns: ["northern sotho", "sepedi", "sesotho sa lebowa"],
+    },
+    { key: "norwegian", patterns: ["norwegian", "norsk"] },
+    { key: "nyanja", patterns: ["nyanja"] },
+    { key: "nyankore", patterns: ["nyankore"] },
+    { key: "nyoro", patterns: ["nyoro"] },
+    { key: "occitan", patterns: ["occitan"] },
+    { key: "odia", patterns: ["odia", "oriya", "ଓଡିଆ"] },
+    { key: "oromo", patterns: ["oromo", "afaan oromo"] },
+    { key: "ossetian", patterns: ["ossetian", "ossetic"] },
+    { key: "pangasinan", patterns: ["pangasinan"] },
+    { key: "papiamento", patterns: ["papiamento"] },
+    { key: "pashto", patterns: ["pashto", "پشتو"] },
+    { key: "pedi", patterns: ["pedi"] },
+    { key: "persian", patterns: ["persian", "farsi", "فارسی"] },
+    { key: "polish", patterns: ["polish", "polski"] },
+    { key: "portuguese", patterns: ["portuguese", "português", "portugues"] },
+    { key: "punjabi", patterns: ["punjabi", "ਪੰਜਾਬੀ"] },
+    { key: "quechua", patterns: ["quechua"] },
+    { key: "romanian", patterns: ["romanian", "română", "romana"] },
+    { key: "romansh", patterns: ["romansh", "rumantsch"] },
+    { key: "romany", patterns: ["romany", "roma"] },
+    { key: "russian", patterns: ["russian", "русский"] },
+    { key: "samoan", patterns: ["samoan"] },
+    { key: "sango", patterns: ["sango"] },
+    { key: "sanskrit", patterns: ["sanskrit", "संस्कृत"] },
+    { key: "santali", patterns: ["santali"] },
+    { key: "scots_gaelic", patterns: ["scots gaelic", "gàidhlig", "gaidhlig"] },
+    { key: "serbian", patterns: ["serbian", "српски"] },
+    { key: "sesotho", patterns: ["sesotho", "sotho"] },
+    { key: "shona", patterns: ["shona"] },
+    { key: "sindhi", patterns: ["sindhi", "सिन्धी", "سنڌي"] },
+    { key: "sinhala", patterns: ["sinhala", "sinhalese", "සිංහල"] },
+    { key: "slovak", patterns: ["slovak", "slovenčina", "slovencina"] },
+    { key: "slovenian", patterns: ["slovenian", "slovenski"] },
+    { key: "somali", patterns: ["somali", "somalia"] },
+    { key: "southern_sotho", patterns: ["southern sotho"] },
+    { key: "spanish", patterns: ["spanish", "español", "espanol"] },
+    { key: "sundanese", patterns: ["sundanese"] },
+    { key: "swahili", patterns: ["swahili", "kiswahili"] },
+    { key: "swati", patterns: ["swati", "siswati"] },
+    { key: "swedish", patterns: ["swedish", "svenska"] },
+    { key: "tagalog", patterns: ["tagalog", "filipino"] },
+    { key: "tahitian", patterns: ["tahitian"] },
+    { key: "tajik", patterns: ["tajik", "тоҷик"] },
+    { key: "tamazight", patterns: ["tamazight", "amazigh"] },
+    { key: "tamil", patterns: ["tamil", "தமிழ்"] },
+    { key: "tatar", patterns: ["tatar"] },
+    { key: "telugu", patterns: ["telugu", "తెలుగు"] },
+    { key: "tetum", patterns: ["tetum"] },
+    { key: "thai", patterns: ["thai", "ไทย"] },
+    { key: "tibetan", patterns: ["tibetan", "བོད་ཡིག"] },
+    { key: "tigrinya", patterns: ["tigrinya", "ትግርኛ"] },
+    { key: "tiv", patterns: ["tiv"] },
+    { key: "tok_pisin", patterns: ["tok pisin"] },
+    { key: "tongan", patterns: ["tongan"] },
+    { key: "tsonga", patterns: ["tsonga"] },
+    { key: "tswana", patterns: ["tswana"] },
+    { key: "tumbuka", patterns: ["tumbuka"] },
+    { key: "turkish", patterns: ["turkish", "türkçe", "turkce"] },
+    { key: "turkmen", patterns: ["turkmen"] },
+    { key: "tuvaluan", patterns: ["tuvaluan"] },
+    { key: "twi", patterns: ["twi"] },
+    { key: "ukrainian", patterns: ["ukrainian", "україн"] },
+    { key: "umbundu", patterns: ["umbundu"] },
+    { key: "urdu", patterns: ["urdu", "اردو"] },
+    { key: "uzbek", patterns: ["uzbek", "oʻzbek"] },
+    { key: "vietnamese", patterns: ["vietnamese", "tiếng việt", "tieng viet"] },
+    { key: "waray", patterns: ["waray"] },
+    { key: "welsh", patterns: ["welsh", "cymraeg"] },
+    { key: "wolof", patterns: ["wolof"] },
+    { key: "xhosa", patterns: ["xhosa"] },
+    { key: "yiddish", patterns: ["yiddish", "ייִדיש"] },
+    { key: "yoruba", patterns: ["yoruba"] },
+    { key: "zulu", patterns: ["zulu", "isizulu"] },
+    { key: "fr", patterns: ["french", "français", "francais", "fr "] },
+    { key: "hi", patterns: ["hindi", "हिंदी", "हिन्दी"] },
+  ];
+  for (const entry of langTests) {
+    if (entry.patterns.some((p) => hintRaw.includes(p))) return entry.key;
+  }
+  return null;
+}
+
+function parseBible(xml, verName) {
+  const result = [];
+  const detectedLang = detectBibleLanguage(xml, verName);
+  const translationMap = detectedLang
+    ? BIBLE_BOOK_TRANSLATIONS[detectedLang]
+    : null;
+  const getAttr = (node, keys) => {
+    if (!node || typeof node.getAttribute !== "function") return null;
+    for (const k of keys) {
+      const val = node.getAttribute(k);
+      if (val) return val;
+    }
+    return null;
+  };
+  const books = [
+    ...xml.querySelectorAll("book, b, bible>b, testament>book"),
+    ...Array.from(xml.getElementsByTagName("BIBLEBOOK")),
+  ];
+
+  books.forEach((b) => {
+    const bNum = getAttr(b, ["number", "n", "bnumber"]);
+    const bNumKey = bNum ? String(parseInt(bNum, 10)) : null;
+    let bName =
+      (bNumKey && translationMap ? translationMap[bNumKey] : null) ||
+      getAttr(b, ["name", "n", "bname"]) ||
+      (bNumKey ? BIBLE_BOOKS[bNumKey] : null) ||
+      "Unknown";
+
+    const chapters = [
+      ...b.querySelectorAll("chapter, c, book>chapter"),
+      ...Array.from(b.getElementsByTagName("CHAPTER")),
+    ];
+
+    chapters.forEach((c) => {
+      const cNum = getAttr(c, ["number", "n", "cnumber"]) || "1";
+      let content = `[${bName} ${cNum}]\n`;
+
+      const verses = [
+        ...c.querySelectorAll("verse, v, chapter>verse"),
+        ...Array.from(c.getElementsByTagName("VERS")),
       ];
-      for (const entry of langTests) {
-        if (entry.patterns.some(p => hintRaw.includes(p))) return entry.key;
-      }
-      return null;
-    }
 
-    function parseBible(xml, verName) {
-      const result = [];
-      const detectedLang = detectBibleLanguage(xml, verName);
-      const translationMap = detectedLang ? BIBLE_BOOK_TRANSLATIONS[detectedLang] : null;
-      const getAttr = (node, keys) => {
-        if (!node || typeof node.getAttribute !== 'function') return null;
-        for (const k of keys) {
-          const val = node.getAttribute(k);
-          if (val) return val;
-        }
-        return null;
-      };
-      const books = [
-        ...xml.querySelectorAll('book, b, bible>b, testament>book'),
-        ...Array.from(xml.getElementsByTagName('BIBLEBOOK'))
-      ];
-      
-      books.forEach(b => {
-        const bNum = getAttr(b, ['number', 'n', 'bnumber']);
-        const bNumKey = bNum ? String(parseInt(bNum, 10)) : null;
-        let bName = (bNumKey && translationMap ? translationMap[bNumKey] : null) ||
-                    getAttr(b, ['name', 'n', 'bname']) ||
-                    (bNumKey ? BIBLE_BOOKS[bNumKey] : null) ||
-                    "Unknown";
-        
-        const chapters = [
-          ...b.querySelectorAll('chapter, c, book>chapter'),
-          ...Array.from(b.getElementsByTagName('CHAPTER'))
-        ];
-        
-        chapters.forEach(c => {
-          const cNum = getAttr(c, ['number', 'n', 'cnumber']) || "1";
-          let content = `[${bName} ${cNum}]\n`;
-          
-          const verses = [
-            ...c.querySelectorAll('verse, v, chapter>verse'),
-            ...Array.from(c.getElementsByTagName('VERS'))
-          ];
-          
-          verses.forEach(v => {
-            const vn = getAttr(v, ['number', 'n', 'vnumber']) || "1";
-            content += `${vn} ${v.textContent.trim()}\n`;
-          });
-          
-          result.push({
-            title: `${bName} ${cNum}`,
-            content,
-            version: verName,
-            book: bName,
-            chapter: cNum
-          });
-        });
+      verses.forEach((v) => {
+        const vn = getAttr(v, ["number", "n", "vnumber"]) || "1";
+        content += `${vn} ${v.textContent.trim()}\n`;
       });
-      
-      if (result.length === 0) {
-        const allChapters = [
-          ...xml.querySelectorAll('c'),
-          ...Array.from(xml.getElementsByTagName('CHAPTER'))
-        ];
-        allChapters.forEach(c => {
-          const parent = c.parentNode || {};
-          const parentNum = getAttr(parent, ['number', 'n', 'bnumber']);
-          const parentNumKey = parentNum ? String(parseInt(parentNum, 10)) : null;
-          const bName = (parentNumKey && translationMap ? translationMap[parentNumKey] : null) ||
-                        getAttr(parent, ['n', 'bname', 'name']) ||
-                        (parentNumKey ? BIBLE_BOOKS[parentNumKey] : null) ||
-                        "Unknown";
-          const cNum = getAttr(c, ['n', 'cnumber', 'number']) || "1";
-          let content = `[${bName} ${cNum}]\n`;
-          
-          const verses = [
-            ...c.querySelectorAll('v'),
-            ...Array.from(c.getElementsByTagName('VERS'))
-          ];
-          verses.forEach(v => {
-            const vn = getAttr(v, ['n', 'vnumber', 'number']) || "1";
-            content += `${vn} ${v.textContent.trim()}\n`;
-          });
-          
-          result.push({
-            title: `${bName} ${cNum}`,
-            content,
-            version: verName,
-            book: bName,
-            chapter: cNum
-          });
-        });
-      }
-      
-      return result;
-    }
 
-    function handleSearch() {
-      const qRaw = (document.getElementById('song-search').value || "");
-      if (sidebarTab === 'bible' && qRaw.trim()) {
-        resetBibleDropdowns();
-      }
-      const currentTab = sidebarTab;
-      setSearchValueForTab(currentTab, qRaw);
-      saveToStorageDebounced();
-      clearTimeout(searchTimer);
-      if (currentTab === 'bible' && parseBibleReferenceQuery(qRaw)) {
-        handleSearchImmediate(qRaw, currentTab);
-        return;
-      }
-      searchTimer = setTimeout(() => handleSearchImmediate(qRaw, currentTab), 120);
-    }
+      result.push({
+        title: `${bName} ${cNum}`,
+        content,
+        version: verName,
+        book: bName,
+        bookNumber: bNumKey
+          ? Number(bNumKey)
+          : getBibleBookNumberFromName(bName),
+        chapter: cNum,
+      });
+    });
+  });
 
-    function handleSearchImmediate(qRaw, tabAtInput) {
-      const targetTab = getSearchTabKey(tabAtInput || sidebarTab);
-      if (sidebarTab !== targetTab) return;
-      let q = normalizeSearchText(qRaw || "");
-      // Normalize "Book chapter verse" to "Book chapter:verse" (space as colon)
-      if (targetTab === 'bible' && !q.includes(':')) {
-        const spaceVerseMatch = q.match(/^([\p{L}1-3 ]+\s+\d+)\s+(\d+(?:-\d+)?)$/u);
-        if (spaceVerseMatch) q = spaceVerseMatch[1] + ':' + spaceVerseMatch[2];
-      }
-      if (targetTab === 'bible' && parseBibleReferenceQuery(q)) {
-        renderBibleSearchResults(q);
-        return;
-      }
-      renderSongs();
-    }
+  if (result.length === 0) {
+    const allChapters = [
+      ...xml.querySelectorAll("c"),
+      ...Array.from(xml.getElementsByTagName("CHAPTER")),
+    ];
+    allChapters.forEach((c) => {
+      const parent = c.parentNode || {};
+      const parentNum = getAttr(parent, ["number", "n", "bnumber"]);
+      const parentNumKey = parentNum ? String(parseInt(parentNum, 10)) : null;
+      const bName =
+        (parentNumKey && translationMap
+          ? translationMap[parentNumKey]
+          : null) ||
+        getAttr(parent, ["n", "bname", "name"]) ||
+        (parentNumKey ? BIBLE_BOOKS[parentNumKey] : null) ||
+        "Unknown";
+      const cNum = getAttr(c, ["n", "cnumber", "number"]) || "1";
+      let content = `[${bName} ${cNum}]\n`;
 
-    function escapeRegex(value) {
-      return String(value || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    }
+      const verses = [
+        ...c.querySelectorAll("v"),
+        ...Array.from(c.getElementsByTagName("VERS")),
+      ];
+      verses.forEach((v) => {
+        const vn = getAttr(v, ["n", "vnumber", "number"]) || "1";
+        content += `${vn} ${v.textContent.trim()}\n`;
+      });
 
-    function handleBibleSpaceToColon(e) {
-      const isSpaceKey = (e.key === ' ' || e.key === 'Space' || e.key === 'Spacebar' || e.code === 'Space');
-      if (!isSpaceKey || sidebarTab !== 'bible') return;
-      const input = e.target;
-      const cursorPos = input.selectionStart;
-      const textBeforeCursor = input.value.substring(0, cursorPos);
-      const textAfterCursor = input.value.substring(cursorPos);
-      // Check if text before cursor matches: bookName chapterNumber (e.g. "Esther 8")
-      const match = textBeforeCursor.match(/^([\p{L}1-3 ]+)\s+(\d+)$/u) ||
-        textBeforeCursor.match(/^([\p{L}1-3 ]+?)(\d+)$/u);
-      if (!match) return;
-      // Only auto-convert when typing at the end or before whitespace.
-      if (textAfterCursor && !/^\s*$/.test(textAfterCursor)) return;
-      const bookCandidate = normalizeSearchText(match[1]).trim();
-      const compactCandidate = bookCandidate.replace(/\s+/g, '');
-      // Ignore very short prefixes to avoid false positives like "a 1".
-      if (bookCandidate.length < 3) return;
-      // Validate against loaded Bible books
-      let isValidBook = false;
-      if (activeBibleVersion && bibles[activeBibleVersion]) {
-        isValidBook = bibles[activeBibleVersion].some(c => {
-          const bookPart = normalizeSearchText(c.title.split(' ').slice(0, -1).join(' '));
-          const compactBookPart = bookPart.replace(/\s+/g, '');
-          return bookPart === bookCandidate ||
-            (bookCandidate.length >= 3 && bookPart.startsWith(bookCandidate)) ||
-            compactBookPart === compactCandidate ||
-            (compactCandidate.length >= 3 && compactBookPart.startsWith(compactCandidate));
-        });
-      }
-      if (!isValidBook) {
-        isValidBook = Object.values(BIBLE_BOOKS).some(b => {
-          const normalized = normalizeSearchText(b);
-          const compactNormalized = normalized.replace(/\s+/g, '');
-          return normalized === bookCandidate ||
-            (bookCandidate.length >= 3 && normalized.startsWith(bookCandidate)) ||
-            compactNormalized === compactCandidate ||
-            (compactCandidate.length >= 3 && compactNormalized.startsWith(compactCandidate));
-        });
-      }
-      if (!isValidBook) return;
-      // Insert colon instead of space
-      e.preventDefault();
-      const after = input.value.substring(cursorPos);
-      let displayBook = String(match[1] || '').trim().replace(/\s+/g, ' ');
-      displayBook = displayBook.replace(/^([1-3])(?=\p{L})/u, '$1 ');
-      const normalizedRefPrefix = `${displayBook} ${match[2]}`.trim();
-      input.value = normalizedRefPrefix + ':' + after;
-      input.selectionStart = input.selectionEnd = normalizedRefPrefix.length + 1;
-      handleSearch();
-    }
+      result.push({
+        title: `${bName} ${cNum}`,
+        content,
+        version: verName,
+        book: bName,
+        bookNumber: parentNumKey
+          ? Number(parentNumKey)
+          : getBibleBookNumberFromName(bName),
+        chapter: cNum,
+      });
+    });
+  }
 
-    function handleSearchEnter(e) {
-      if (e.key !== 'Enter') return;
-      const qRaw = (document.getElementById('song-search').value || "");
-      let q = normalizeSearchText(qRaw).trim();
-      if (sidebarTab !== 'bible') return;
-      // Normalize "Book chapter verse" to "Book chapter:verse" (space as colon)
-      if (!q.includes(':')) {
-        const spaceVerseMatch = q.match(/^([\p{L}1-3 ]+\s+\d+)\s+(\d+(?:-\d+)?)$/u);
-        if (spaceVerseMatch) q = spaceVerseMatch[1] + ':' + spaceVerseMatch[2];
-      }
-      if (!q.includes(':')) return;
-      e.preventDefault();
-      const parsed = parseBibleReferenceQuery(q);
-      if (!parsed || !parsed.versePrefix) { handleSearch(); return; }
-      const verseStart = parsed.versePrefix;
-      const verseEnd = null;
-      if (!activeBibleVersion && Object.keys(bibles).length > 0) {
-        activeBibleVersion = Object.keys(bibles)[0];
-        renderVersionBar();
-      }
-      if (!activeBibleVersion || !bibles[activeBibleVersion]) return;
-      const chapterMatch = findBibleReferenceChapter(activeBibleVersion, parsed);
-      if (!chapterMatch) return;
-      const idx = chapterMatch.chapterIndex;
-      selectItem(idx, { skipButtonView: true });
-      setBibleGroupAnchor(verseStart, currentItem);
-      const pages = getPagesFromItem(currentItem, true);
-      const pageIdx = pages.findIndex(p => matchesVerseStart(p.raw, verseStart));
-      if (pageIdx !== -1) {
-        lineCursor = pageIdx;
-        updateButtonView();
-        projectLive(true);
-      }
-      const picked = bibles[activeBibleVersion][idx];
-      const extracted = extractBookAndChapter(picked);
-      addBibleRecentReference(buildBibleRefEntry(extracted.book, extracted.chap, verseStart, verseEnd, activeBibleVersion));
-    }
+  return result;
+}
 
-    function getIsBibleItem(item) { return !!(item && item.version) }
+function handleSearch() {
+  const qRaw = document.getElementById("song-search").value || "";
+  if (sidebarTab === "bible" && qRaw.trim()) {
+    resetBibleDropdowns();
+  }
+  const currentTab = sidebarTab;
+  setSearchValueForTab(currentTab, qRaw);
+  saveToStorageDebounced();
+  clearTimeout(searchTimer);
+  if (currentTab === "bible" && parseBibleReferenceQuery(qRaw)) {
+    handleSearchImmediate(qRaw, currentTab);
+    return;
+  }
+  searchTimer = setTimeout(() => handleSearchImmediate(qRaw, currentTab), 120);
+}
 
-    function getButtonContextList() {
-      if (buttonContextTab === 'songs') return songs;
-      if (buttonContextTab === 'schedule') return schedule;
-      return (activeBibleVersion && bibles[activeBibleVersion]) ? (bibles[activeBibleVersion] || []) : [];
-    }
+function handleSearchImmediate(qRaw, tabAtInput) {
+  const targetTab = getSearchTabKey(tabAtInput || sidebarTab);
+  if (sidebarTab !== targetTab) return;
+  let q = normalizeSearchText(qRaw || "");
+  // Normalize "Book chapter verse" to "Book chapter:verse" (space as colon)
+  if (targetTab === "bible" && !q.includes(":")) {
+    const spaceVerseMatch = q.match(/^([\p{L}1-3 ]+\s+\d+)\s+(\d+(?:-\d+)?)$/u);
+    if (spaceVerseMatch) q = spaceVerseMatch[1] + ":" + spaceVerseMatch[2];
+  }
+  if (targetTab === "bible" && parseBibleReferenceQuery(q)) {
+    renderBibleSearchResults(q);
+    return;
+  }
+  renderSongs();
+}
 
-    function selectItem(i, opts = {}) {
-      const preserveLineCursor = !!opts.preserveLineCursor;
-      const preserveButtonScroll = !!opts.preserveButtonScroll;
-      const skipButtonView = !!opts.skipButtonView;
-      let list = getButtonContextList();
-      currentIndex = i; currentItem = list[i] || null;
-      if (!currentItem) return;
-      if (!getIsBibleItem(currentItem)) normalizeSongTranslationState(currentItem);
-      document.getElementById('lyric-editor').value = currentItem.content || "";
-      refreshSongTranslationPanel(currentItem);
-      if (!preserveLineCursor) lineCursor = 0;
-      const isBibleEntry = getIsBibleItem(currentItem);
-      if (isBibleEntry) {
-        bibleGroupAnchorKey = getBibleItemKey(currentItem);
-        if (!preserveLineCursor) {
-          bibleGroupAnchorVerse = null;
-        }
-      }
-      if (sidebarTab === 'schedule' && isBibleEntry) {
-        const scheduleLines = getScheduleLineHint(currentItem);
-        if (scheduleLines != null && linesPerPage !== scheduleLines) {
-          setLines(scheduleLines, { silent: true });
-        }
-      }
-      renderSongs();
-      if (!skipButtonView) {
-        updateButtonView({ preserveScroll: preserveButtonScroll, skipAutoScroll: preserveButtonScroll });
-      }
-      enforceBibleModeRules();
-      maybeTranslateCurrentSongOnOpen();
-      if (!preserveButtonScroll && !skipButtonView) scrollButtonsToTop();
-      saveToStorageDebounced();
-    }
+function escapeRegex(value) {
+  return String(value || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
-    function focusActiveSongInSidebar() {
-      const list = document.getElementById('song-list');
-      if (!list) return;
-      const active = list.querySelector('.song-item.active');
-      if (!active) return;
-      active.scrollIntoView({ block: 'center', behavior: 'smooth' });
+function handleBibleSpaceToColon(e) {
+  const isSpaceKey =
+    e.key === " " ||
+    e.key === "Space" ||
+    e.key === "Spacebar" ||
+    e.code === "Space";
+  if (!isSpaceKey || sidebarTab !== "bible") return;
+  const input = e.target;
+  const cursorPos = input.selectionStart;
+  const textBeforeCursor = input.value.substring(0, cursorPos);
+  const textAfterCursor = input.value.substring(cursorPos);
+  // Check if text before cursor matches: bookName chapterNumber (e.g. "Esther 8")
+  const match =
+    textBeforeCursor.match(/^([\p{L}1-3 ]+)\s+(\d+)$/u) ||
+    textBeforeCursor.match(/^([\p{L}1-3 ]+?)(\d+)$/u);
+  if (!match) return;
+  // Only auto-convert when typing at the end or before whitespace.
+  if (textAfterCursor && !/^\s*$/.test(textAfterCursor)) return;
+  const bookCandidate = normalizeSearchText(match[1]).trim();
+  const compactCandidate = bookCandidate.replace(/\s+/g, "");
+  // Ignore very short prefixes to avoid false positives like "a 1".
+  if (bookCandidate.length < 3) return;
+
+  // Validate using the universal Bible book resolver.
+  //
+  // This intentionally does NOT depend on the currently loaded
+  // Bible's language. For example:
+  //
+  //   John 3      -> book 43
+  //   Jòhánù 3   -> book 43
+  //   Johannes 3 -> book 43
+  //
+  // Therefore the colon conversion works regardless of the
+  // language of the imported Bible.
+  const bookNumber = getBibleBookNumberFromName(bookCandidate);
+
+  if (bookNumber == null) return;
+
+  // Insert colon instead of space
+  e.preventDefault();
+  const after = input.value.substring(cursorPos);
+  let displayBook = String(match[1] || "")
+    .trim()
+    .replace(/\s+/g, " ");
+  displayBook = displayBook.replace(/^([1-3])(?=\p{L})/u, "$1 ");
+  const normalizedRefPrefix = `${displayBook} ${match[2]}`.trim();
+  input.value = normalizedRefPrefix + ":" + after;
+  input.selectionStart = input.selectionEnd = normalizedRefPrefix.length + 1;
+  handleSearch();
+}
+
+function handleSearchEnter(e) {
+  if (e.key !== "Enter") return;
+  const qRaw = document.getElementById("song-search").value || "";
+  let q = normalizeSearchText(qRaw).trim();
+  if (sidebarTab !== "bible") return;
+  // Normalize "Book chapter verse" to "Book chapter:verse" (space as colon)
+  if (!q.includes(":")) {
+    const spaceVerseMatch = q.match(/^([\p{L}1-3 ]+\s+\d+)\s+(\d+(?:-\d+)?)$/u);
+    if (spaceVerseMatch) q = spaceVerseMatch[1] + ":" + spaceVerseMatch[2];
+  }
+  if (!q.includes(":")) return;
+  e.preventDefault();
+  const parsed = parseBibleReferenceQuery(q);
+  if (!parsed || !parsed.versePrefix) {
+    handleSearch();
+    return;
+  }
+  const verseStart = parsed.versePrefix;
+  const verseEnd = null;
+  if (!activeBibleVersion && Object.keys(bibles).length > 0) {
+    activeBibleVersion = Object.keys(bibles)[0];
+    renderVersionBar();
+  }
+  if (!activeBibleVersion || !bibles[activeBibleVersion]) return;
+  const chapterMatch = findBibleReferenceChapter(activeBibleVersion, parsed);
+  if (!chapterMatch) return;
+  const idx = chapterMatch.chapterIndex;
+  selectItem(idx, { skipButtonView: true });
+  setBibleGroupAnchor(verseStart, currentItem);
+  const pages = getPagesFromItem(currentItem, true);
+  const pageIdx = pages.findIndex((p) => matchesVerseStart(p.raw, verseStart));
+  if (pageIdx !== -1) {
+    lineCursor = pageIdx;
+    updateButtonView();
+    projectLive(true);
+  }
+  const picked = bibles[activeBibleVersion][idx];
+  const extracted = extractBookAndChapter(picked);
+  addBibleRecentReference(
+    buildBibleRefEntry(
+      extracted.book,
+      extracted.chap,
+      verseStart,
+      verseEnd,
+      activeBibleVersion,
+    ),
+  );
+}
+
+function getIsBibleItem(item) {
+  return !!(item && item.version);
+}
+
+function getButtonContextList() {
+  if (buttonContextTab === "songs") return songs;
+  if (buttonContextTab === "schedule") return schedule;
+  return activeBibleVersion && bibles[activeBibleVersion]
+    ? bibles[activeBibleVersion] || []
+    : [];
+}
+
+function selectItem(i, opts = {}) {
+  const preserveLineCursor = !!opts.preserveLineCursor;
+  const preserveButtonScroll = !!opts.preserveButtonScroll;
+  const skipButtonView = !!opts.skipButtonView;
+  let list = getButtonContextList();
+  currentIndex = i;
+  currentItem = list[i] || null;
+  if (!currentItem) return;
+  if (!getIsBibleItem(currentItem)) normalizeSongTranslationState(currentItem);
+  document.getElementById("lyric-editor").value = currentItem.content || "";
+  refreshSongTranslationPanel(currentItem);
+  if (!preserveLineCursor) lineCursor = 0;
+  const isBibleEntry = getIsBibleItem(currentItem);
+  if (isBibleEntry) {
+    bibleGroupAnchorKey = getBibleItemKey(currentItem);
+    if (!preserveLineCursor) {
+      bibleGroupAnchorVerse = null;
     }
+  }
+  if (sidebarTab === "schedule" && isBibleEntry) {
+    const scheduleLines = getScheduleLineHint(currentItem);
+    if (scheduleLines != null && linesPerPage !== scheduleLines) {
+      setLines(scheduleLines, { silent: true });
+    }
+  }
+  renderSongs();
+  if (!skipButtonView) {
+    updateButtonView({
+      preserveScroll: preserveButtonScroll,
+      skipAutoScroll: preserveButtonScroll,
+    });
+  }
+  enforceBibleModeRules();
+  maybeTranslateCurrentSongOnOpen();
+  if (!preserveButtonScroll && !skipButtonView) scrollButtonsToTop();
+  saveToStorageDebounced();
+}
+
+function focusActiveSongInSidebar() {
+  const list = document.getElementById("song-list");
+  if (!list) return;
+  const active = list.querySelector(".song-item.active");
+  if (!active) return;
+  active.scrollIntoView({ block: "center", behavior: "smooth" });
+}

--- a/js/panel/state-and-storage.js
+++ b/js/panel/state-and-storage.js
@@ -1,1276 +1,2009 @@
+// ===== DB =====
+function openDb() {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_SONGS)) {
+        db.createObjectStore(STORE_SONGS, { keyPath: "id" });
+      }
+      if (!db.objectStoreNames.contains(STORE_BIBLES)) {
+        db.createObjectStore(STORE_BIBLES, { keyPath: "id" });
+      }
+      if (!db.objectStoreNames.contains(STORE_STATE)) {
+        db.createObjectStore(STORE_STATE, { keyPath: "key" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  return dbPromise;
+}
 
-    // ===== DB =====
-    function openDb() {
-      if (dbPromise) return dbPromise;
-      dbPromise = new Promise((resolve, reject) => {
-        const req = indexedDB.open(DB_NAME, DB_VERSION);
-        req.onupgradeneeded = () => {
-          const db = req.result;
-          if (!db.objectStoreNames.contains(STORE_SONGS)) {
-            db.createObjectStore(STORE_SONGS, { keyPath: 'id' });
-          }
-          if (!db.objectStoreNames.contains(STORE_BIBLES)) {
-            db.createObjectStore(STORE_BIBLES, { keyPath: 'id' });
-          }
-          if (!db.objectStoreNames.contains(STORE_STATE)) {
-            db.createObjectStore(STORE_STATE, { keyPath: 'key' });
-          }
-        };
-        req.onsuccess = () => resolve(req.result);
-        req.onerror = () => reject(req.error);
-      });
-      return dbPromise;
-    }
-
-    function idbGet(storeName, key) {
-      return openDb().then(db => new Promise((resolve, reject) => {
-        const tx = db.transaction(storeName, 'readonly');
+function idbGet(storeName, key) {
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readonly");
         const store = tx.objectStore(storeName);
         const req = store.get(key);
         req.onsuccess = () => resolve(req.result || null);
         req.onerror = () => reject(req.error);
-      }));
-    }
+      }),
+  );
+}
 
-    function idbGetAll(storeName) {
-      return openDb().then(db => new Promise((resolve, reject) => {
-        const tx = db.transaction(storeName, 'readonly');
+function idbGetAll(storeName) {
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readonly");
         const store = tx.objectStore(storeName);
         const req = store.getAll();
         req.onsuccess = () => resolve(req.result || []);
         req.onerror = () => reject(req.error);
-      }));
-    }
+      }),
+  );
+}
 
-    function idbPut(storeName, value) {
-      if (storeName === STORE_SONGS) queueRelayStatePush({ includeSongs: true });
-      if (storeName === STORE_BIBLES) queueRelayStatePush({ includeBibles: true });
-      return openDb().then(db => new Promise((resolve, reject) => {
-        const tx = db.transaction(storeName, 'readwrite');
+function idbPut(storeName, value) {
+  if (storeName === STORE_SONGS) queueRelayStatePush({ includeSongs: true });
+  if (storeName === STORE_BIBLES) queueRelayStatePush({ includeBibles: true });
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readwrite");
         const store = tx.objectStore(storeName);
         store.put(value);
         tx.oncomplete = () => resolve(true);
         tx.onerror = () => reject(tx.error);
         tx.onabort = () => reject(tx.error);
-      }));
-    }
+      }),
+  );
+}
 
-    function idbDelete(storeName, key) {
-      return openDb().then(db => new Promise((resolve, reject) => {
-        const tx = db.transaction(storeName, 'readwrite');
+function idbDelete(storeName, key) {
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readwrite");
         const store = tx.objectStore(storeName);
         store.delete(key);
         tx.oncomplete = () => resolve(true);
         tx.onerror = () => reject(tx.error);
         tx.onabort = () => reject(tx.error);
-      }));
-    }
+      }),
+  );
+}
 
-    function dbGetAll(storeName) {
-      return idbGetAll(storeName);
-    }
+function dbGetAll(storeName) {
+  return idbGetAll(storeName);
+}
 
-    function dbPutMany(storeName, records) {
-      const items = Array.isArray(records) ? records : [];
-      if (!items.length) return Promise.resolve(true);
-      if (storeName === STORE_SONGS) queueRelayStatePush({ includeSongs: true });
-      if (storeName === STORE_BIBLES) queueRelayStatePush({ includeBibles: true });
-      return openDb().then(db => new Promise((resolve, reject) => {
-        const tx = db.transaction(storeName, 'readwrite');
+function dbPutMany(storeName, records) {
+  const items = Array.isArray(records) ? records : [];
+  if (!items.length) return Promise.resolve(true);
+  if (storeName === STORE_SONGS) queueRelayStatePush({ includeSongs: true });
+  if (storeName === STORE_BIBLES) queueRelayStatePush({ includeBibles: true });
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readwrite");
         const store = tx.objectStore(storeName);
-        items.forEach(item => store.put(item));
+        items.forEach((item) => store.put(item));
         tx.oncomplete = () => resolve(true);
         tx.onerror = () => reject(tx.error);
         tx.onabort = () => reject(tx.error);
-      }));
-    }
+      }),
+  );
+}
 
-    function dbClearStore(storeName) {
-      if (storeName === STORE_SONGS) queueRelayStatePush({ includeSongs: true });
-      if (storeName === STORE_BIBLES) queueRelayStatePush({ includeBibles: true });
-      return openDb().then(db => new Promise((resolve, reject) => {
-        const tx = db.transaction(storeName, 'readwrite');
+function dbClearStore(storeName) {
+  if (storeName === STORE_SONGS) queueRelayStatePush({ includeSongs: true });
+  if (storeName === STORE_BIBLES) queueRelayStatePush({ includeBibles: true });
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readwrite");
         const store = tx.objectStore(storeName);
         store.clear();
         tx.oncomplete = () => resolve(true);
         tx.onerror = () => reject(tx.error);
         tx.onabort = () => reject(tx.error);
-      }));
-    }
+      }),
+  );
+}
 
-    function dbSetAppState(nextState, opts = {}) {
-      const updatedAt = opts.updatedAt || Date.now();
-      appStateUpdatedAt = updatedAt;
-      const payload = { key: 'appState', value: nextState, updatedAt };
-      return idbPut(STORE_STATE, payload);
-    }
+function dbSetAppState(nextState, opts = {}) {
+  const updatedAt = opts.updatedAt || Date.now();
+  appStateUpdatedAt = updatedAt;
+  const payload = { key: "appState", value: nextState, updatedAt };
+  return idbPut(STORE_STATE, payload);
+}
 
-    function persistLtStyles() {
-      if (isRestoringBackup) return Promise.resolve(false);
-      const json = safeStringify(ltStyles);
-      const payload = { key: 'ltStyles', value: json, format: 'json', updatedAt: Date.now() };
-      return idbPut(STORE_STATE, payload).catch(() => false);
-    }
+function persistLtStyles() {
+  if (isRestoringBackup) return Promise.resolve(false);
+  const json = safeStringify(ltStyles);
+  const payload = {
+    key: "ltStyles",
+    value: json,
+    format: "json",
+    updatedAt: Date.now(),
+  };
+  return idbPut(STORE_STATE, payload).catch(() => false);
+}
 
-    function flushAppState() {
-      if (isRestoringBackup) return Promise.resolve(false);
-      syncAppStateFromUi();
-      const updatedAt = isApplyingRemoteState ? (appStateUpdatedAt || Date.now()) : Date.now();
-      appStateUpdatedAt = updatedAt;
-      const payload = { key: 'appState', value: appState, updatedAt };
-      return idbPut(STORE_STATE, payload).catch(() => false);
-    }
+function flushAppState() {
+  if (isRestoringBackup) return Promise.resolve(false);
+  syncAppStateFromUi();
+  const updatedAt = isApplyingRemoteState
+    ? appStateUpdatedAt || Date.now()
+    : Date.now();
+  appStateUpdatedAt = updatedAt;
+  const payload = { key: "appState", value: appState, updatedAt };
+  return idbPut(STORE_STATE, payload).catch(() => false);
+}
 
-    // ===== UTILITIES / SEARCH =====
-    function normalizeSearchText(value) {
-      return String(value || '')
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f\u1ab0-\u1aff\u1dc0-\u1dff\u20d0-\u20ff\ufe20-\ufe2f]/g, '')
-        .replace(/[\u2018\u2019]/g, "'")
-        .toLowerCase()
-        // Keep ":" for chapter:verse refs; normalize other separators/punctuation.
-        .replace(/[^\p{L}\p{N}:]+/gu, ' ')
-        .replace(/\s+/g, ' ')
-        .trim();
-    }
+// ===== UTILITIES / SEARCH =====
+function normalizeSearchText(value) {
+  return (
+    String(value || "")
+      .normalize("NFD")
+      .replace(
+        /[\u0300-\u036f\u1ab0-\u1aff\u1dc0-\u1dff\u20d0-\u20ff\ufe20-\ufe2f]/g,
+        "",
+      )
+      .replace(/[\u2018\u2019]/g, "'")
+      .toLowerCase()
+      // Keep ":" for chapter:verse refs; normalize other separators/punctuation.
+      .replace(/[^\p{L}\p{N}:]+/gu, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}
 
-    function getItemSearchableText(item) {
-      if (!item) return '';
-      if (item.version) return normalizeSearchText(item.title || '');
-      if (item.searchableText) return item.searchableText;
-      const base = `${item.title || ''}\n${item.content || item.text || ''}`;
-      return normalizeSearchText(base);
-    }
+function getItemSearchableText(item) {
+  if (!item) return "";
+  if (item.version) return normalizeSearchText(item.title || "");
+  if (item.searchableText) return item.searchableText;
+  const base = `${item.title || ""}\n${item.content || item.text || ""}`;
+  return normalizeSearchText(base);
+}
 
-    const bibleSearchCache = new Map();
+const bibleSearchCache = new Map();
 
-    function clearBibleSearchCache(versionId) {
-      if (versionId) bibleSearchCache.delete(versionId);
-      else bibleSearchCache.clear();
-    }
+function clearBibleSearchCache(versionId) {
+  if (versionId) bibleSearchCache.delete(versionId);
+  else bibleSearchCache.clear();
+}
 
-    function buildBibleSearchIndex(versionId) {
-      const list = (versionId && bibles[versionId]) ? bibles[versionId] : [];
-      const entries = [];
-      list.forEach((item, chapterIndex) => {
-        const extracted = extractBookAndChapter(item);
-        const book = item?.book || extracted.book || '';
-        const chap = item?.chapter || extracted.chap || '';
-        const lines = String(item?.content || '').split('\n');
-        lines.forEach((line) => {
-          const match = line.match(/^(\d+)\s+(.+)/);
-          if (!match) return;
-          const verse = match[1];
-          const text = match[2];
-          const searchText = normalizeSearchText(`${book} ${chap}:${verse} ${text}`);
-          entries.push({ chapterIndex, book, chapter: chap, verse, text, searchText });
-        });
-      });
-      return { entries, size: list.length };
-    }
-
-    function getBibleSearchIndex(versionId) {
-      const list = (versionId && bibles[versionId]) ? bibles[versionId] : [];
-      const cached = bibleSearchCache.get(versionId);
-      if (cached && cached.size === list.length) return cached.entries;
-      const built = buildBibleSearchIndex(versionId);
-      bibleSearchCache.set(versionId, built);
-      return built.entries;
-    }
-
-    function parseBibleReferenceQuery(raw) {
-      const q = normalizeSearchText(raw).trim();
-      if (!q) return null;
-      const match = q.match(/^([\p{L}1-3 ]+)\s+(\d+)(?::(\d*))?$/u);
-      if (!match) return null;
-      const [, bookRaw, chapterRaw, versePrefixRaw] = match;
-      const book = normalizeSearchText(bookRaw).trim();
-      const chapter = String(chapterRaw || '').trim();
-      const versePrefix = String(versePrefixRaw || '');
-      const hasColon = q.includes(':');
-      return {
-        raw,
-        normalizedQuery: q,
+function buildBibleSearchIndex(versionId) {
+  const list = versionId && bibles[versionId] ? bibles[versionId] : [];
+  const entries = [];
+  list.forEach((item, chapterIndex) => {
+    const extracted = extractBookAndChapter(item);
+    const book = item?.book || extracted.book || "";
+    const chap = item?.chapter || extracted.chap || "";
+    const lines = String(item?.content || "").split("\n");
+    lines.forEach((line) => {
+      const match = line.match(/^(\d+)\s+(.+)/);
+      if (!match) return;
+      const verse = match[1];
+      const text = match[2];
+      const searchText = normalizeSearchText(
+        `${book} ${chap}:${verse} ${text}`,
+      );
+      entries.push({
+        chapterIndex,
         book,
-        chapter,
-        versePrefix,
-        hasColon,
-        isChapterQuery: !hasColon || !versePrefix,
-        isVersePrefixQuery: hasColon && !!versePrefix
-      };
-    }
-
-    function isBibleReferenceQuery(raw) {
-      return !!parseBibleReferenceQuery(raw);
-    }
-
-    function findBibleReferenceChapter(versionId, query, opts = {}) {
-      const parsed = (query && typeof query === 'object' && query.chapter)
-        ? query
-        : parseBibleReferenceQuery(query);
-      if (!parsed) return null;
-      const list = (versionId && bibles[versionId]) ? bibles[versionId] : [];
-      if (!list.length) return null;
-      const selectedBookKey = normalizeBookName(opts.book || '');
-      const bookNeedle = normalizeBookName(parsed.book);
-      const compactBookNeedle = bookNeedle.replace(/\s+/g, '');
-      let chapterIndex = -1;
-      let chapterItem = null;
-
-      for (let index = 0; index < list.length; index += 1) {
-        const item = list[index];
-        const extracted = extractBookAndChapter(item);
-        const itemBook = item?.book || extracted.book || '';
-        const itemBookKey = normalizeBookName(itemBook);
-        const itemCompactBookKey = itemBookKey.replace(/\s+/g, '');
-        const itemChapter = String(item?.chapter || extracted.chap || '').trim();
-        if (!itemBookKey || !itemChapter) continue;
-        if (selectedBookKey && itemBookKey !== selectedBookKey) continue;
-        if (itemChapter !== parsed.chapter) continue;
-        const bookMatches =
-          itemBookKey === bookNeedle ||
-          itemBookKey.startsWith(bookNeedle) ||
-          itemCompactBookKey === compactBookNeedle ||
-          itemCompactBookKey.startsWith(compactBookNeedle);
-        if (!bookMatches) continue;
-        chapterIndex = index;
-        chapterItem = item;
-        break;
-      }
-
-      if (chapterIndex === -1 || !chapterItem) return null;
-      return { chapterIndex, chapterItem, parsed };
-    }
-
-    function findBibleReferenceMatches(query, opts = {}) {
-      const parsed = (query && typeof query === 'object' && query.chapter)
-        ? query
-        : parseBibleReferenceQuery(query);
-      if (!parsed) return [];
-      const versionId = opts.versionId || activeBibleVersion;
-      if (!versionId || !bibles[versionId]) return [];
-      const chapterMatch = findBibleReferenceChapter(versionId, parsed, opts);
-      if (!chapterMatch) return [];
-      const { chapterIndex, chapterItem } = chapterMatch;
-      const results = [];
-      String(chapterItem.content || '').split('\n').forEach((line) => {
-        const match = String(line || '').match(/^(\d+)\s+(.+)/);
-        if (!match) return;
-        const verse = match[1];
-        if (parsed.versePrefix && !verse.startsWith(parsed.versePrefix)) return;
-        results.push({
-          chapterIndex,
-          book: chapterItem.book || extractBookAndChapter(chapterItem).book,
-          chapter: parsed.chapter,
-          verse,
-          text: match[2]
-        });
-      });
-      return results;
-    }
-
-    function findBibleKeywordMatches(query, opts = {}) {
-      const q = normalizeSearchText(query).trim();
-      if (!q || q.length < 2) return [];
-      const tokens = q.split(/\s+/).filter(Boolean);
-      if (!tokens.length) return [];
-      const maxResults = opts.maxResults || 200;
-      const versionId = opts.versionId || activeBibleVersion;
-      if (!versionId || !bibles[versionId]) return [];
-      const selectedBook = opts.book || '';
-      const bookKey = normalizeBookName(selectedBook);
-      const entries = getBibleSearchIndex(versionId);
-      const results = [];
-      for (const entry of entries) {
-        if (bookKey && normalizeBookName(entry.book) !== bookKey) continue;
-        if (!tokens.every(t => entry.searchText.includes(t))) continue;
-        results.push(entry);
-        if (results.length >= maxResults) break;
-      }
-      return results;
-    }
-
-    function slugify(value) {
-      return String(value || '')
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/(^-|-$)/g, '');
-    }
-
-    function createId(prefix, value) {
-      const base = slugify(value).slice(0, 32) || 'item';
-      return `${prefix}_${base}_${Math.random().toString(36).slice(2, 8)}`;
-    }
-
-    function buildSongRecord(song, { isNew = false } = {}) {
-      const now = Date.now();
-      const id = song.id || createId('song', song.title);
-      const text = song.text || song.content || '';
-      const searchableText = normalizeSearchText(`${song.title || ''}\n${text}`);
-      const normalizedLines = text.split('\n');
-      return {
-        id,
-        title: song.title || '',
+        chapter: chap,
+        verse,
         text,
-        translatedLyrics: String(song.translatedLyrics || ''),
-        translationLanguage: String(song.translationLanguage || ''),
-        translationStatus: String(song.translationStatus || 'idle'),
-        translationLocked: !!song.translationLocked,
-        translatedAt: Number(song.translatedAt || 0),
-        translationHash: String(song.translationHash || ''),
-        bilingualEnabled: !!song.bilingualEnabled,
-        normalizedLines,
-        searchableText,
-        createdAt: isNew ? now : (song.createdAt || now),
-        updatedAt: now
-      };
-    }
-
-    function hydrateSongFromRecord(record) {
-      return normalizeSongTranslationState({
-        id: record.id,
-        title: record.title || '',
-        content: record.text || '',
-        text: record.text || '',
-        translatedLyrics: String(record.translatedLyrics || ''),
-        translationLanguage: String(record.translationLanguage || ''),
-        translationStatus: String(record.translationStatus || 'idle'),
-        translationLocked: !!record.translationLocked,
-        translatedAt: Number(record.translatedAt || 0),
-        translationHash: String(record.translationHash || ''),
-        bilingualEnabled: !!record.bilingualEnabled,
-        searchableText: record.searchableText || normalizeSearchText(`${record.title || ''}\n${record.text || ''}`),
-        createdAt: record.createdAt || Date.now(),
-        updatedAt: record.updatedAt || Date.now()
+        searchText,
       });
-    }
+    });
+  });
+  return { entries, size: list.length };
+}
 
-    function scheduleSongPersist(song) {
-      if (!song) return;
-      clearTimeout(songSaveTimer);
-      songSaveTimer = setTimeout(() => {
-        const record = buildSongRecord(song);
-        song.id = record.id;
-        song.searchableText = record.searchableText;
-        song.createdAt = record.createdAt;
-        song.updatedAt = record.updatedAt;
-        idbPut(STORE_SONGS, record).catch(() => {});
-      }, 400);
-    }
+function getBibleSearchIndex(versionId) {
+  const list = versionId && bibles[versionId] ? bibles[versionId] : [];
+  const cached = bibleSearchCache.get(versionId);
+  if (cached && cached.size === list.length) return cached.entries;
+  const built = buildBibleSearchIndex(versionId);
+  bibleSearchCache.set(versionId, built);
+  return built.entries;
+}
 
-    function buildBibleRecord(name, parsedData, { isNew = false, createdAt = null } = {}) {
-      const now = Date.now();
-      const id = name;
-      const searchableText = normalizeSearchText(name);
-      const createdAtValue = createdAt || (isNew ? now : now);
-      return {
-        id,
-        name,
-        parsedData: Array.isArray(parsedData) ? parsedData : [],
-        searchableText,
-        createdAt: createdAtValue,
-        updatedAt: now
-      };
-    }
+function getBibleBookNumberFromName(rawName) {
+  const needle = normalizeSearchText(rawName || "").trim();
+  if (!needle) return null;
 
-    function persistBibleVersion(name) {
-      const data = bibles[name] || [];
-      const record = buildBibleRecord(name, data);
-      return idbPut(STORE_BIBLES, record);
-    }
+  const compactNeedle = needle.replace(/\s+/g, "");
 
-    function schedulePersistAppState() {
-      if (!stateReady || isRestoringBackup) {
-        pendingPersist = true;
-        return;
-      }
-      clearTimeout(saveTimer);
-      saveTimer = setTimeout(() => {
-        saveToStorage();
-      }, 500);
-    }
+  // 1. Canonical English Bible names.
+  for (const [number, name] of Object.entries(BIBLE_BOOKS || {})) {
+    const normalized = normalizeSearchText(name);
+    const compact = normalized.replace(/\s+/g, "");
 
-    function getBackgroundSnapshot() {
-      const bgTypeEl = document.getElementById('bg-type');
-      if (!bgTypeEl) return null;
-      const snapshot = {
-        bgType: bgTypeEl.value,
-        bgImageSource: document.getElementById('bg-image-source')?.value,
-        bgImageUrl: document.getElementById('bg-image-url')?.value,
-        bgUploadDataUrl,
-        bgVideoSource: document.getElementById('bg-video-source')?.value,
-        bgVideoUrl: document.getElementById('bg-video-url')?.value,
-        bgVideoUploadDataUrl,
-        bgVideoLoop: document.getElementById('bg-video-loop')?.checked,
-        bgVideoSpeed: document.getElementById('bg-video-speed')?.value,
-        bgMode,
-        bgColor: document.getElementById('bg-color-quick')?.value,
-        bgGradientShadow: document.getElementById('bg-color-shadow')?.value,
-        bgGradientHighlight: document.getElementById('bg-color-highlight')?.value,
-        bgBlur: document.getElementById('bg-blur')?.value,
-        bgEdgeFix: document.getElementById('bg-edge-fix')?.value,
-        bgOpacity: getActiveBgOpacityValue(),
-        bgOpacityFull,
-        bgOpacityLT,
-        bgY: document.getElementById('bg-y')?.value,
-        bgToggle: document.getElementById('bg-toggle')?.checked,
-        animateBgTransitions: document.getElementById('animate-bg-transitions')?.checked,
-        bgGradientAngle: document.getElementById('bg-gradient-angle')?.value || 135
-      };
-      return snapshot;
+    if (normalized === needle || compact === compactNeedle) {
+      return Number(number);
     }
+  }
 
-    function applyBackgroundSnapshot(target, snapshot) {
-      if (!target || !snapshot) return;
-      BG_SETTINGS_KEYS.forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
-          target[key] = snapshot[key];
+  // 2. All localized Bible book names.
+  // BIBLE_BOOK_TRANSLATIONS is already maintained by the application
+  // and maps every supported language to the standard 66 Bible books.
+  if (typeof BIBLE_BOOK_TRANSLATIONS !== "undefined") {
+    for (const translationMap of Object.values(BIBLE_BOOK_TRANSLATIONS || {})) {
+      if (!translationMap || typeof translationMap !== "object") continue;
+
+      for (const [number, name] of Object.entries(translationMap)) {
+        const normalized = normalizeSearchText(name);
+        const compact = normalized.replace(/\s+/g, "");
+
+        if (normalized === needle || compact === compactNeedle) {
+          return Number(number);
         }
+      }
+    }
+  }
+
+  // 3. Common English abbreviations.
+  // These are useful because people frequently type references such as: Jn 3:16, Rom 8:28, 1 Cor 13:4, etc.
+  const abbreviations = {
+    gen: 1,
+    ge: 1,
+
+    ex: 2,
+    exod: 2,
+
+    lev: 3,
+
+    num: 4,
+
+    deut: 5,
+    dt: 5,
+    de: 5,
+
+    josh: 6,
+    jos: 6,
+
+    judg: 7,
+    jdg: 7,
+
+    ruth: 8,
+    ru: 8,
+
+    "1 sam": 9,
+    "1sam": 9,
+    "1sa": 9,
+    "2 sam": 10,
+    "2sam": 10,
+    "2sa": 10,
+
+    "1 kgs": 11,
+    "1 ki": 11,
+    "1ki": 11,
+    "2 kgs": 12,
+    "2 ki": 12,
+    "2ki": 12,
+
+    "1 chr": 13,
+    "1 ch": 13,
+    "1chr": 13,
+    "1 chron": 13,
+    "1chron": 13,
+    "2 chr": 14,
+    "2 ch": 14,
+    "2chr": 14,
+    "2 chron": 14,
+    "2chron": 14,
+
+    ezra: 15,
+    ezr: 15,
+    ez: 15,
+
+    neh: 16,
+    ne: 16,
+
+    est: 17,
+    es: 17,
+
+    job: 18,
+
+    ps: 19,
+    psa: 19,
+    psalms: 19,
+
+    prov: 20,
+    pro: 20,
+
+    eccl: 21,
+    ecc: 21,
+    eccles: 21,
+
+    song: 22,
+    sos: 22,
+    sol: 22,
+
+    isa: 23,
+
+    jer: 24,
+
+    lam: 25,
+
+    ezek: 26,
+    eze: 26,
+
+    dan: 27,
+
+    hos: 28,
+
+    joel: 29,
+    amos: 30,
+    obad: 31,
+    ob: 31,
+    jon: 32,
+    mic: 33,
+    nah: 34,
+    hab: 35,
+
+    zeph: 36,
+    zep: 36,
+
+    hag: 37,
+
+    zech: 38,
+    zec: 38,
+
+    mal: 39,
+
+    matt: 40,
+    mat: 40,
+    mt: 40,
+
+    mark: 41,
+    mar: 41,
+    mk: 41,
+
+    luke: 42,
+    luk: 42,
+    lk: 42,
+
+    john: 43,
+    jn: 43,
+
+    acts: 44,
+    act: 44,
+    ac: 44,
+
+    rom: 45,
+    ro: 45,
+
+    "1 cor": 46,
+    "1co": 46,
+    "2 cor": 47,
+    "2co": 47,
+
+    gal: 48,
+    eph: 49,
+
+    phil: 50,
+    phi: 50,
+    php: 50,
+
+    col: 51,
+
+    "1 thess": 52,
+    "1th": 52,
+    "2 thess": 53,
+    "2th": 53,
+
+    "1 tim": 54,
+    "1ti": 54,
+    "2 tim": 55,
+    "2ti": 55,
+
+    tit: 56,
+
+    philem: 57,
+    phi: 57,
+    phm: 57,
+
+    heb: 58,
+
+    jas: 59,
+    james: 59,
+    jam: 59,
+
+    "1 pet": 60,
+    "1pe": 60,
+    "2 pet": 61,
+    "2pe": 61,
+
+    "1 john": 62,
+    "1jn": 62,
+    "2 john": 63,
+    "2jn": 63,
+    "3 john": 64,
+    "3jn": 64,
+
+    jude: 65,
+    rev: 66,
+  };
+
+  if (Object.prototype.hasOwnProperty.call(abbreviations, needle)) {
+    return abbreviations[needle];
+  }
+
+  return null;
+}
+
+function parseBibleReferenceQuery(raw) {
+  const q = normalizeSearchText(raw).trim();
+
+  if (!q) return null;
+
+  const match = q.match(/^([\p{L}\p{N}1-3 ]+)\s+(\d+)(?::(\d*))?$/u);
+
+  if (!match) return null;
+
+  const [, bookRaw, chapterRaw, versePrefixRaw] = match;
+
+  const book = normalizeSearchText(bookRaw).trim();
+  const chapter = String(chapterRaw || "").trim();
+  const versePrefix = String(versePrefixRaw || "");
+
+  const hasColon = q.includes(":");
+
+  const bookNumber = getBibleBookNumberFromName(book);
+
+  return {
+    raw,
+    normalizedQuery: q,
+    book,
+    chapter,
+    versePrefix,
+    hasColon,
+
+    // Canonical Bible book number.
+    // null means the user typed something that is not currently recognized as a Bible book name/alias.
+    bookNumber,
+
+    isChapterQuery: !hasColon || !versePrefix,
+    isVersePrefixQuery: hasColon && !!versePrefix,
+  };
+}
+
+function isBibleReferenceQuery(raw) {
+  return !!parseBibleReferenceQuery(raw);
+}
+
+function findBibleReferenceChapter(versionId, query, opts = {}) {
+  const parsed =
+    query && typeof query === "object" && query.chapter
+      ? query
+      : parseBibleReferenceQuery(query);
+
+  if (!parsed) return null;
+
+  const list = versionId && bibles[versionId] ? bibles[versionId] : [];
+
+  if (!list.length) return null;
+
+  /*
+   * Resolve the user's book name into the canonical 1–66
+   * Bible book number.
+   *
+   * Example:
+   *
+   *   John       -> 43
+   *   Jòhánù     -> 43
+   *   Johannes   -> 43
+   *   Yoruba etc -> 43
+   */
+  const parsedBookNumber = Number.isFinite(Number(parsed.bookNumber))
+    ? Number(parsed.bookNumber)
+    : getBibleBookNumberFromName(parsed.book);
+
+  /*
+   * opts.book is normally used when the UI has already selected a book. Resolve it using exactly the same universal book resolver instead of comparing localized strings.
+   */
+  const selectedBookNumber = opts.book
+    ? getBibleBookNumberFromName(opts.book)
+    : null;
+
+  let chapterIndex = -1;
+  let chapterItem = null;
+
+  for (let index = 0; index < list.length; index += 1) {
+    const item = list[index];
+
+    const extracted = extractBookAndChapter(item);
+
+    const itemBook = String(item?.book || extracted.book || "").trim();
+
+    const itemChapter = String(item?.chapter || extracted.chap || "").trim();
+
+    if (!itemBook || !itemChapter) continue;
+
+    /*
+     * Chapter must always match exactly.
+     */
+    if (itemChapter !== parsed.chapter) continue;
+
+    /* If the UI supplied a selected book, it must make sure it refers to the same canonical Bible book.
+     */
+    if (selectedBookNumber != null) {
+      const itemBookNumber = Number.isFinite(Number(item?.bookNumber))
+        ? Number(item.bookNumber)
+        : getBibleBookNumberFromName(itemBook);
+
+      if (itemBookNumber !== selectedBookNumber) continue;
+    }
+
+    /*
+     * The important part: This compares canonical Bible book numbers instead of comparing the imported Bible's localized book name with the search string.
+     */
+    if (parsedBookNumber != null) {
+      const itemBookNumber = Number.isFinite(Number(item?.bookNumber))
+        ? Number(item.bookNumber)
+        : getBibleBookNumberFromName(itemBook);
+
+      if (itemBookNumber !== parsedBookNumber) continue;
+    } else {
+      /*
+       * If the book cannot be resolved to a canonical number, it retains the old matching behavior as a fallback.
+       */
+      const bookNeedle = normalizeSearchText(parsed.book);
+      const itemBookKey = normalizeSearchText(itemBook);
+
+      const compactBookNeedle = bookNeedle.replace(/\s+/g, "");
+
+      const itemCompactBookKey = itemBookKey.replace(/\s+/g, "");
+
+      const bookMatches =
+        itemBookKey === bookNeedle ||
+        itemBookKey.startsWith(bookNeedle) ||
+        itemCompactBookKey === compactBookNeedle ||
+        itemCompactBookKey.startsWith(compactBookNeedle);
+
+      if (!bookMatches) continue;
+    }
+
+    chapterIndex = index;
+    chapterItem = item;
+    break;
+  }
+
+  if (chapterIndex === -1 || !chapterItem) {
+    return null;
+  }
+
+  return {
+    chapterIndex,
+    chapterItem,
+    parsed,
+  };
+}
+
+function findBibleReferenceMatches(query, opts = {}) {
+  const parsed =
+    query && typeof query === "object" && query.chapter
+      ? query
+      : parseBibleReferenceQuery(query);
+  if (!parsed) return [];
+  const versionId = opts.versionId || activeBibleVersion;
+  if (!versionId || !bibles[versionId]) return [];
+  const chapterMatch = findBibleReferenceChapter(versionId, parsed, opts);
+  if (!chapterMatch) return [];
+  const { chapterIndex, chapterItem } = chapterMatch;
+  const results = [];
+  String(chapterItem.content || "")
+    .split("\n")
+    .forEach((line) => {
+      const match = String(line || "").match(/^(\d+)\s+(.+)/);
+      if (!match) return;
+      const verse = match[1];
+      if (parsed.versePrefix && !verse.startsWith(parsed.versePrefix)) return;
+      results.push({
+        chapterIndex,
+        book: chapterItem.book || extractBookAndChapter(chapterItem).book,
+        chapter: parsed.chapter,
+        verse,
+        text: match[2],
       });
+    });
+  return results;
+}
+
+function findBibleKeywordMatches(query, opts = {}) {
+  const q = normalizeSearchText(query).trim();
+  if (!q || q.length < 2) return [];
+  const tokens = q.split(/\s+/).filter(Boolean);
+  if (!tokens.length) return [];
+  const maxResults = opts.maxResults || 200;
+  const versionId = opts.versionId || activeBibleVersion;
+  if (!versionId || !bibles[versionId]) return [];
+  const selectedBook = opts.book || "";
+  const bookKey = normalizeBookName(selectedBook);
+  const entries = getBibleSearchIndex(versionId);
+  const results = [];
+  for (const entry of entries) {
+    if (bookKey && normalizeBookName(entry.book) !== bookKey) continue;
+    if (!tokens.every((t) => entry.searchText.includes(t))) continue;
+    results.push(entry);
+    if (results.length >= maxResults) break;
+  }
+  return results;
+}
+
+function slugify(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function createId(prefix, value) {
+  const base = slugify(value).slice(0, 32) || "item";
+  return `${prefix}_${base}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildSongRecord(song, { isNew = false } = {}) {
+  const now = Date.now();
+  const id = song.id || createId("song", song.title);
+  const text = song.text || song.content || "";
+  const searchableText = normalizeSearchText(`${song.title || ""}\n${text}`);
+  const normalizedLines = text.split("\n");
+  return {
+    id,
+    title: song.title || "",
+    text,
+    translatedLyrics: String(song.translatedLyrics || ""),
+    translationLanguage: String(song.translationLanguage || ""),
+    translationStatus: String(song.translationStatus || "idle"),
+    translationLocked: !!song.translationLocked,
+    translatedAt: Number(song.translatedAt || 0),
+    translationHash: String(song.translationHash || ""),
+    bilingualEnabled: !!song.bilingualEnabled,
+    normalizedLines,
+    searchableText,
+    createdAt: isNew ? now : song.createdAt || now,
+    updatedAt: now,
+  };
+}
+
+function hydrateSongFromRecord(record) {
+  return normalizeSongTranslationState({
+    id: record.id,
+    title: record.title || "",
+    content: record.text || "",
+    text: record.text || "",
+    translatedLyrics: String(record.translatedLyrics || ""),
+    translationLanguage: String(record.translationLanguage || ""),
+    translationStatus: String(record.translationStatus || "idle"),
+    translationLocked: !!record.translationLocked,
+    translatedAt: Number(record.translatedAt || 0),
+    translationHash: String(record.translationHash || ""),
+    bilingualEnabled: !!record.bilingualEnabled,
+    searchableText:
+      record.searchableText ||
+      normalizeSearchText(`${record.title || ""}\n${record.text || ""}`),
+    createdAt: record.createdAt || Date.now(),
+    updatedAt: record.updatedAt || Date.now(),
+  });
+}
+
+function scheduleSongPersist(song) {
+  if (!song) return;
+  clearTimeout(songSaveTimer);
+  songSaveTimer = setTimeout(() => {
+    const record = buildSongRecord(song);
+    song.id = record.id;
+    song.searchableText = record.searchableText;
+    song.createdAt = record.createdAt;
+    song.updatedAt = record.updatedAt;
+    idbPut(STORE_SONGS, record).catch(() => {});
+  }, 400);
+}
+
+function buildBibleRecord(
+  name,
+  parsedData,
+  { isNew = false, createdAt = null } = {},
+) {
+  const now = Date.now();
+  const id = name;
+  const searchableText = normalizeSearchText(name);
+  const createdAtValue = createdAt || (isNew ? now : now);
+  return {
+    id,
+    name,
+    parsedData: Array.isArray(parsedData) ? parsedData : [],
+    searchableText,
+    createdAt: createdAtValue,
+    updatedAt: now,
+  };
+}
+
+function persistBibleVersion(name) {
+  const data = bibles[name] || [];
+  const record = buildBibleRecord(name, data);
+  return idbPut(STORE_BIBLES, record);
+}
+
+function schedulePersistAppState() {
+  if (!stateReady || isRestoringBackup) {
+    pendingPersist = true;
+    return;
+  }
+  clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    saveToStorage();
+  }, 500);
+}
+
+function getBackgroundSnapshot() {
+  const bgTypeEl = document.getElementById("bg-type");
+  if (!bgTypeEl) return null;
+  const snapshot = {
+    bgType: bgTypeEl.value,
+    bgImageSource: document.getElementById("bg-image-source")?.value,
+    bgImageUrl: document.getElementById("bg-image-url")?.value,
+    bgUploadDataUrl,
+    bgVideoSource: document.getElementById("bg-video-source")?.value,
+    bgVideoUrl: document.getElementById("bg-video-url")?.value,
+    bgVideoUploadDataUrl,
+    bgVideoLoop: document.getElementById("bg-video-loop")?.checked,
+    bgVideoSpeed: document.getElementById("bg-video-speed")?.value,
+    bgMode,
+    bgColor: document.getElementById("bg-color-quick")?.value,
+    bgGradientShadow: document.getElementById("bg-color-shadow")?.value,
+    bgGradientHighlight: document.getElementById("bg-color-highlight")?.value,
+    bgBlur: document.getElementById("bg-blur")?.value,
+    bgEdgeFix: document.getElementById("bg-edge-fix")?.value,
+    bgOpacity: getActiveBgOpacityValue(),
+    bgOpacityFull,
+    bgOpacityLT,
+    bgY: document.getElementById("bg-y")?.value,
+    bgToggle: document.getElementById("bg-toggle")?.checked,
+    animateBgTransitions: document.getElementById("animate-bg-transitions")
+      ?.checked,
+    bgGradientAngle: document.getElementById("bg-gradient-angle")?.value || 135,
+  };
+  return snapshot;
+}
+
+function applyBackgroundSnapshot(target, snapshot) {
+  if (!target || !snapshot) return;
+  BG_SETTINGS_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
+      target[key] = snapshot[key];
     }
+  });
+}
 
-    function extractBackgroundSnapshot(settings) {
-      if (!settings || typeof settings !== 'object') return null;
-      const snapshot = {};
-      BG_SETTINGS_KEYS.forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(settings, key)) {
-          snapshot[key] = settings[key];
-        }
-      });
-      return Object.keys(snapshot).length ? snapshot : null;
+function extractBackgroundSnapshot(settings) {
+  if (!settings || typeof settings !== "object") return null;
+  const snapshot = {};
+  BG_SETTINGS_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(settings, key)) {
+      snapshot[key] = settings[key];
     }
+  });
+  return Object.keys(snapshot).length ? snapshot : null;
+}
 
-    function getAnimationSnapshot() {
-      const typeEl = document.getElementById('song-transition-type');
-      if (!typeEl) return null;
-      return {
-        songTransitionType: typeEl.value,
-        songTransitionDuration: document.getElementById('song-transition-duration')?.value,
-        animateBgTransitions: document.getElementById('animate-bg-transitions')?.checked
-      };
+function getAnimationSnapshot() {
+  const typeEl = document.getElementById("song-transition-type");
+  if (!typeEl) return null;
+  return {
+    songTransitionType: typeEl.value,
+    songTransitionDuration: document.getElementById("song-transition-duration")
+      ?.value,
+    animateBgTransitions: document.getElementById("animate-bg-transitions")
+      ?.checked,
+  };
+}
+
+function applyAnimationSnapshot(target, snapshot) {
+  if (!target || !snapshot) return;
+  ANIMATION_SETTINGS_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
+      target[key] = snapshot[key];
     }
+  });
+}
 
-    function applyAnimationSnapshot(target, snapshot) {
-      if (!target || !snapshot) return;
-      ANIMATION_SETTINGS_KEYS.forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
-          target[key] = snapshot[key];
-        }
-      });
+function extractAnimationSnapshot(settings) {
+  if (!settings || typeof settings !== "object") return null;
+  const snapshot = {};
+  ANIMATION_SETTINGS_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(settings, key)) {
+      snapshot[key] = settings[key];
     }
+  });
+  return Object.keys(snapshot).length ? snapshot : null;
+}
 
-    function extractAnimationSnapshot(settings) {
-      if (!settings || typeof settings !== 'object') return null;
-      const snapshot = {};
-      ANIMATION_SETTINGS_KEYS.forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(settings, key)) {
-          snapshot[key] = settings[key];
-        }
-      });
-      return Object.keys(snapshot).length ? snapshot : null;
+function persistAnimationState() {
+  if (!stateReady || isRestoringBackup) {
+    pendingAnimationPersist = true;
+    return;
+  }
+  const snapshot = getAnimationSnapshot();
+  if (!snapshot) return;
+  const payload = {
+    key: "animationSettings",
+    value: snapshot,
+    updatedAt: Date.now(),
+  };
+  idbPut(STORE_STATE, payload).catch(() => {});
+}
+
+function schedulePersistAnimation() {
+  if (!stateReady || isRestoringBackup) {
+    pendingAnimationPersist = true;
+    return;
+  }
+  clearTimeout(animationSaveTimer);
+  animationSaveTimer = setTimeout(() => {
+    persistAnimationState();
+  }, 500);
+}
+
+function getTypographySnapshot() {
+  const familyEl = document.getElementById("font-family");
+  if (!familyEl) return null;
+  return {
+    fontFamily: familyEl.value,
+    fontWeight: document.getElementById("font-weight")?.value,
+    fontSizeFull: document.getElementById("font-size-val")?.value,
+    fullTextTransform,
+    ltFontSongs,
+    ltFontBible,
+    ltFontCustom,
+    refFontSize: document.getElementById("ref-font-size-val")?.value,
+    lineHeightFull: document.getElementById("line-height-full")?.value,
+    lineHeightLT: document.getElementById("line-height-lt")?.value,
+    textColor: document.getElementById("text-color")?.value,
+    refColor: document.getElementById("ref-color")?.value,
+    refBgColor: document.getElementById("ref-bg-color")?.value,
+    dualVersionModeEnabled,
+    dualVersionSecondaryId,
+  };
+}
+
+function applyTypographySnapshot(target, snapshot) {
+  if (!target || !snapshot) return;
+  TYPOGRAPHY_SETTINGS_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
+      target[key] = snapshot[key];
     }
+  });
+}
 
-    function persistAnimationState() {
-      if (!stateReady || isRestoringBackup) {
-        pendingAnimationPersist = true;
-        return;
-      }
-      const snapshot = getAnimationSnapshot();
-      if (!snapshot) return;
-      const payload = { key: 'animationSettings', value: snapshot, updatedAt: Date.now() };
-      idbPut(STORE_STATE, payload).catch(() => {});
+function extractTypographySnapshot(settings) {
+  if (!settings || typeof settings !== "object") return null;
+  const snapshot = {};
+  TYPOGRAPHY_SETTINGS_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(settings, key)) {
+      snapshot[key] = settings[key];
     }
+  });
+  return Object.keys(snapshot).length ? snapshot : null;
+}
 
-    function schedulePersistAnimation() {
-      if (!stateReady || isRestoringBackup) {
-        pendingAnimationPersist = true;
-        return;
-      }
-      clearTimeout(animationSaveTimer);
-      animationSaveTimer = setTimeout(() => {
-        persistAnimationState();
-      }, 500);
+function persistTypographyState() {
+  if (!stateReady || isRestoringBackup) {
+    pendingTypographyPersist = true;
+    return;
+  }
+  const snapshot = getTypographySnapshot();
+  if (!snapshot) return;
+  const payload = {
+    key: "typographySettings",
+    value: snapshot,
+    updatedAt: Date.now(),
+  };
+  idbPut(STORE_STATE, payload).catch(() => {});
+}
+
+function schedulePersistTypography() {
+  if (!stateReady || isRestoringBackup) {
+    pendingTypographyPersist = true;
+    return;
+  }
+  clearTimeout(typographySaveTimer);
+  typographySaveTimer = setTimeout(() => {
+    persistTypographyState();
+  }, 500);
+}
+
+function getModeSettingsSnapshot() {
+  const fullSizeEl = document.getElementById("font-size-val");
+  if (!fullSizeEl) return null;
+  return {
+    fontSizeFull: fullSizeEl.value,
+    lineHeightFull: document.getElementById("line-height-full")?.value,
+    fullTextTransform:
+      document.getElementById("full-text-transform")?.value ||
+      fullTextTransform,
+    autoResizeFull: document.getElementById("auto-resize-full")?.value,
+    autoResizeLT: document.getElementById("auto-resize-lt")?.value,
+    refPositionFull: document.getElementById("ref-position-full")?.value,
+    hAlignFullRef: fullRefHAlign,
+    hAlignFull: fullHAlign,
+    vAlignFull: fullVAlign,
+    ltFontSongs,
+    ltFontBible,
+    ltFontCustom,
+    lineHeightLT: document.getElementById("line-height-lt")?.value,
+    hAlignLTSongs: ltHAlignSongs,
+    vAlignLTSongs: ltVAlignSongs,
+    ltAnchorMode,
+    hAlignLTBible: ltHAlignBible,
+    vAlignLTBible: ltVAlignBible,
+    hAlignLTBibleVerse: ltHAlignBibleVerse,
+    autoAdjustLtHeight: document.getElementById("auto-adjust-lt-height")
+      ?.checked,
+    refBgColor: document.getElementById("ref-bg-color")?.value,
+    refBgEnabled: refBgEnabled,
+    ltRefFontSize: document.getElementById("ref-font-size-lt-val")?.value,
+    referenceShadowEnabled: referenceShadowEnabled,
+    verseShadowEnabled: verseShadowEnabled,
+    referenceTextCapitalized: document.getElementById("capitalize-ref-text")
+      ?.checked,
+    showVersion: document.getElementById("show-version")?.checked,
+    shortenBibleVersions: document.getElementById("shorten-bible-versions")
+      ?.checked,
+    shortenBibleBooks: document.getElementById("shorten-bible-books")?.checked,
+    showVerseNos: document.getElementById("show-verse-nos")?.checked,
+    versionSwitchUpdatesLive: document.getElementById(
+      "version-switch-updates-live",
+    )?.checked,
+    dualVersionModeEnabled: dualVersionModeEnabled,
+    dualVersionSecondaryId: dualVersionSecondaryId,
+  };
+}
+
+function applyModeSettingsSnapshot(target, snapshot) {
+  if (!target || !snapshot) return;
+  MODE_SETTINGS_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
+      target[key] = snapshot[key];
     }
+  });
+}
 
-    function getTypographySnapshot() {
-      const familyEl = document.getElementById('font-family');
-      if (!familyEl) return null;
-      return {
-        fontFamily: familyEl.value,
-        fontWeight: document.getElementById('font-weight')?.value,
-        fontSizeFull: document.getElementById('font-size-val')?.value,
-        fullTextTransform,
-        ltFontSongs,
-        ltFontBible,
-        ltFontCustom,
-        refFontSize: document.getElementById('ref-font-size-val')?.value,
-        lineHeightFull: document.getElementById('line-height-full')?.value,
-        lineHeightLT: document.getElementById('line-height-lt')?.value,
-        textColor: document.getElementById('text-color')?.value,
-        refColor: document.getElementById('ref-color')?.value,
-        refBgColor: document.getElementById('ref-bg-color')?.value,
-        dualVersionModeEnabled,
-        dualVersionSecondaryId
-      };
+function extractModeSettingsSnapshot(settings) {
+  if (!settings || typeof settings !== "object") return null;
+  const snapshot = {};
+  MODE_SETTINGS_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(settings, key)) {
+      snapshot[key] = settings[key];
     }
+  });
+  return Object.keys(snapshot).length ? snapshot : null;
+}
 
-    function applyTypographySnapshot(target, snapshot) {
-      if (!target || !snapshot) return;
-      TYPOGRAPHY_SETTINGS_KEYS.forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
-          target[key] = snapshot[key];
-        }
-      });
+const PROJECTION_SETTINGS_PROFILE_KEYS = Array.from(
+  new Set([
+    "fontFamily",
+    "fontWeight",
+    "fontSizeFull",
+    "fullTextTransform",
+    "ltFontSongs",
+    "ltFontBible",
+    "ltFontCustom",
+    "refFontSize",
+    "lineHeightFull",
+    "lineHeightLT",
+    "textColor",
+    "refColor",
+    "refBgColor",
+    "bgType",
+    "bgImageSource",
+    "bgImageUrl",
+    "bgUploadDataUrl",
+    "bgVideoSource",
+    "bgVideoUrl",
+    "bgVideoUploadDataUrl",
+    "bgVideoLoop",
+    "bgVideoSpeed",
+    "bgMode",
+    "bgColor",
+    "bgGradientShadow",
+    "bgGradientHighlight",
+    "bgBlur",
+    "bgEdgeFix",
+    "bgOpacity",
+    "bgOpacityFull",
+    "bgOpacityLT",
+    "bgY",
+    "bgToggle",
+    "animateBgTransitions",
+    "bgGradientAngle",
+    "ltRefFontSize",
+    "linesPerPage",
+    "activeRatio",
+    "ltTextTransform",
+    "fullRefTextTransform",
+    "ltRefTextTransform",
+    "showVersion",
+    "showVerseNos",
+    "shortenBibleVersions",
+    "shortenBibleBooks",
+    "autoAdjustLtHeight",
+    "autoResizeFull",
+    "autoResizeLT",
+    "refPositionFull",
+    "ltWidthPct",
+    "ltScalePct",
+    "ltOffsetX",
+    "ltOffsetY",
+    "ltBorderRadius",
+    "padLRFull",
+    "padLRLT",
+    "hAlignFullRef",
+    "hAlignFull",
+    "vAlignFull",
+    "hAlignLTSongs",
+    "vAlignLTSongs",
+    "ltAnchorMode",
+    "hAlignLTBible",
+    "vAlignLTBible",
+    "hAlignLTBibleVerse",
+    "referenceShadowEnabled",
+    "verseShadowEnabled",
+    "referenceTextCapitalized",
+    "refBgEnabled",
+    "ltPresetSelection",
+    "ltPresetUpdatesLive",
+    "dualVersionModeEnabled",
+    "dualVersionSecondaryId",
+  ]),
+);
+const SETTINGS_TARGET_TABS = ["bible", "songs", "schedule"];
+// Media is a settings target but not a projection-settings profile: it keeps its own
+// defaults (see media-workspace.js) and must not read or write typography profiles.
+const MEDIA_SETTINGS_TABS = new Set([
+  "media",
+  "presets",
+  "themes",
+  "updates",
+  "feedback",
+]);
+let mediaSettingsTargetActive = false;
+
+function normalizeSettingsTargetTab(value) {
+  return value === "follow" || SETTINGS_TARGET_TABS.includes(value)
+    ? value
+    : "follow";
+}
+
+function getEffectiveSettingsTargetTab(target = settingsTargetTab) {
+  const normalized = normalizeSettingsTargetTab(target);
+  return normalized === "follow" ? sidebarTab || "bible" : normalized;
+}
+
+function captureProjectionSettingsSnapshot() {
+  return {
+    ...(getTypographySnapshot() || {}),
+    ...(getBackgroundSnapshot() || {}),
+    fontSizeFull: document.getElementById("font-size-val")?.value,
+    ltFontSongs,
+    ltFontBible,
+    ltFontCustom,
+    refFontSize: document.getElementById("ref-font-size-val")?.value,
+    ltRefFontSize: document.getElementById("ref-font-size-lt-val")?.value,
+    lineHeightFull: document.getElementById("line-height-full")?.value,
+    lineHeightLT: document.getElementById("line-height-lt")?.value,
+    textColor: document.getElementById("text-color")?.value,
+    refColor: document.getElementById("ref-color")?.value,
+    refBgColor: document.getElementById("ref-bg-color")?.value,
+    linesPerPage,
+    activeRatio,
+    fullTextTransform:
+      document.getElementById("full-text-transform")?.value ||
+      fullTextTransform,
+    ltTextTransform:
+      document.getElementById("lt-text-transform")?.value ||
+      ltTextTransform ||
+      "uppercase",
+    fullRefTextTransform:
+      document.getElementById("full-ref-text-transform")?.value ||
+      fullRefTextTransform ||
+      "uppercase",
+    ltRefTextTransform:
+      document.getElementById("lt-ref-text-transform")?.value ||
+      ltRefTextTransform ||
+      "uppercase",
+    showVersion: document.getElementById("show-version")?.checked,
+    showVerseNos: document.getElementById("show-verse-nos")?.checked,
+    shortenBibleVersions: document.getElementById("shorten-bible-versions")
+      ?.checked,
+    shortenBibleBooks: document.getElementById("shorten-bible-books")?.checked,
+    autoAdjustLtHeight: document.getElementById("auto-adjust-lt-height")
+      ?.checked,
+    autoResizeFull: document.getElementById("auto-resize-full")?.value,
+    autoResizeLT: document.getElementById("auto-resize-lt")?.value,
+    refPositionFull: document.getElementById("ref-position-full")?.value,
+    ltPresetSelection:
+      document.getElementById("lt-preset-select")?.value || "default",
+    ltPresetUpdatesLive:
+      document.getElementById("lt-preset-update-live")?.value !== "false",
+    ltWidthPct: document.getElementById("lt-width-pct")?.value,
+    ltScalePct: document.getElementById("lt-scale-pct")?.value,
+    ltOffsetX: document.getElementById("lt-offset-x")?.value,
+    ltOffsetY: document.getElementById("lt-offset-y")?.value,
+    ltBorderRadius: document.getElementById("lt-border-radius")?.value,
+    padLRFull: document.getElementById("pad-lr-full")?.value ?? 5,
+    padLRLT: document.getElementById("pad-lr-lt")?.value ?? 5,
+    hAlignFullRef: fullRefHAlign,
+    hAlignFull: fullHAlign,
+    vAlignFull: fullVAlign,
+    hAlignLTSongs: ltHAlignSongs,
+    vAlignLTSongs: ltVAlignSongs,
+    ltAnchorMode,
+    hAlignLTBible: ltHAlignBible,
+    vAlignLTBible: ltVAlignBible,
+    hAlignLTBibleVerse: ltHAlignBibleVerse,
+    referenceShadowEnabled,
+    verseShadowEnabled,
+    referenceTextCapitalized: document.getElementById("capitalize-ref-text")
+      ?.checked,
+    refBgEnabled,
+    dualVersionModeEnabled,
+    dualVersionSecondaryId,
+  };
+}
+
+function normalizeProjectionSettingsSnapshot(raw, fallback = {}) {
+  const next = { ...fallback };
+  const source = raw && typeof raw === "object" ? raw : {};
+  PROJECTION_SETTINGS_PROFILE_KEYS.forEach((key) => {
+    if (
+      Object.prototype.hasOwnProperty.call(source, key) &&
+      source[key] != null
+    )
+      next[key] = source[key];
+  });
+  return next;
+}
+
+function createDefaultProjectionSettingsProfiles(seed = null) {
+  const base = normalizeProjectionSettingsSnapshot(
+    seed || captureProjectionSettingsSnapshot(),
+    {},
+  );
+  return {
+    bible: {
+      ...base,
+      ltPresetSelection: "rounded-card",
+      autoResizeLT: "shrink",
+      lineHeightLT: 1.1,
+      padLRLT: 5,
+      ltWidthPct: 100,
+      ltScalePct: 80,
+      ltOffsetX: 0,
+      ltOffsetY: 25,
+      ltBorderRadius: 23,
+      autoAdjustLtHeight: true,
+      hAlignLTBible: "center",
+      vAlignLTBible: "middle",
+      hAlignLTBibleVerse: "center",
+      ltAnchorMode: "bottom",
+      bgOpacityFull: 100,
+      bgOpacityLT: 100,
+    },
+    songs: {
+      ...base,
+      ltWidthPct: 60,
+      ltOffsetX: 0,
+      ltOffsetY: 50,
+      bgOpacityFull: 100,
+      bgOpacityLT: 100,
+    },
+    schedule: { ...base },
+  };
+}
+
+function ensureProjectionSettingsProfiles(seed = null) {
+  if (
+    !projectionSettingsProfilesByTab ||
+    typeof projectionSettingsProfilesByTab !== "object"
+  ) {
+    projectionSettingsProfilesByTab =
+      createDefaultProjectionSettingsProfiles(seed);
+  }
+  const defaults = createDefaultProjectionSettingsProfiles(seed);
+  SETTINGS_TARGET_TABS.forEach((tab) => {
+    projectionSettingsProfilesByTab[tab] = normalizeProjectionSettingsSnapshot(
+      projectionSettingsProfilesByTab[tab],
+      defaults[tab],
+    );
+  });
+  return projectionSettingsProfilesByTab;
+}
+
+function loadProjectionSettingsProfilesFromUi(ui) {
+  const seed = normalizeProjectionSettingsSnapshot(
+    ui || {},
+    captureProjectionSettingsSnapshot(),
+  );
+  projectionSettingsProfilesByTab =
+    createDefaultProjectionSettingsProfiles(seed);
+  const source =
+    ui &&
+    ui.projectionSettingsProfiles &&
+    typeof ui.projectionSettingsProfiles === "object"
+      ? ui.projectionSettingsProfiles
+      : {};
+  SETTINGS_TARGET_TABS.forEach((tab) => {
+    projectionSettingsProfilesByTab[tab] = normalizeProjectionSettingsSnapshot(
+      source[tab],
+      projectionSettingsProfilesByTab[tab],
+    );
+  });
+  settingsTargetTab = normalizeSettingsTargetTab(ui?.settingsTargetTab);
+  return projectionSettingsProfilesByTab;
+}
+
+function saveProjectionSettingsProfileForTab(
+  tab = getEffectiveSettingsTargetTab(),
+) {
+  if (!SETTINGS_TARGET_TABS.includes(tab)) return null;
+  const profiles = ensureProjectionSettingsProfiles();
+  profiles[tab] = normalizeProjectionSettingsSnapshot(
+    captureProjectionSettingsSnapshot(),
+    profiles[tab],
+  );
+  return profiles[tab];
+}
+
+function getProjectionSettingsSnapshotForTab(
+  tab = getEffectiveSettingsTargetTab(),
+) {
+  if (!SETTINGS_TARGET_TABS.includes(tab))
+    return normalizeProjectionSettingsSnapshot(
+      captureProjectionSettingsSnapshot(),
+      {},
+    );
+  const profiles = ensureProjectionSettingsProfiles();
+  return normalizeProjectionSettingsSnapshot(
+    profiles[tab],
+    captureProjectionSettingsSnapshot(),
+  );
+}
+
+function applyProjectionRuntimeSnapshot(profile) {
+  const next = normalizeProjectionSettingsSnapshot(
+    profile,
+    captureProjectionSettingsSnapshot(),
+  );
+  if (typeof next.fullTextTransform !== "undefined")
+    fullTextTransform = next.fullTextTransform;
+  if (typeof next.ltTextTransform !== "undefined")
+    ltTextTransform = next.ltTextTransform;
+  if (typeof next.fullRefTextTransform !== "undefined")
+    fullRefTextTransform = next.fullRefTextTransform;
+  if (typeof next.ltRefTextTransform !== "undefined")
+    ltRefTextTransform = next.ltRefTextTransform;
+  if (next.ltFontSongs != null) ltFontSongs = Number(next.ltFontSongs);
+  if (next.ltFontBible != null) ltFontBible = Number(next.ltFontBible);
+  if (next.ltFontCustom != null) ltFontCustom = Number(next.ltFontCustom);
+  if (next.ltRefFontSize != null) ltRefFontSize = Number(next.ltRefFontSize);
+  if (next.linesPerPage != null)
+    linesPerPage = Math.max(
+      1,
+      Math.min(
+        getMaxLinesForCurrentTab(sidebarTab),
+        Number(next.linesPerPage) || 1,
+      ),
+    );
+  if (next.activeRatio)
+    activeRatio = next.activeRatio === "16-9" ? "16-9" : "full";
+  if (next.autoAdjustLtHeight != null)
+    autoAdjustLtHeight = !!next.autoAdjustLtHeight;
+  fullRefHAlign = next.hAlignFullRef || fullRefHAlign;
+  fullHAlign = next.hAlignFull || fullHAlign;
+  fullVAlign = next.vAlignFull || fullVAlign;
+  ltHAlignSongs = next.hAlignLTSongs || ltHAlignSongs;
+  ltVAlignSongs = next.vAlignLTSongs || ltVAlignSongs;
+  ltAnchorMode = next.ltAnchorMode === "top" ? "top" : "bottom";
+  ltHAlignBible = next.hAlignLTBible || ltHAlignBible;
+  ltVAlignBible = next.vAlignLTBible || ltVAlignBible;
+  ltHAlignBibleVerse = next.hAlignLTBibleVerse || ltHAlignBibleVerse;
+  if (next.refBgEnabled != null) refBgEnabled = !!next.refBgEnabled;
+  if (next.referenceShadowEnabled != null)
+    referenceShadowEnabled = !!next.referenceShadowEnabled;
+  if (next.verseShadowEnabled != null)
+    verseShadowEnabled = !!next.verseShadowEnabled;
+  if (next.referenceTextCapitalized != null)
+    referenceTextCapitalized = !!next.referenceTextCapitalized;
+  if (next.dualVersionModeEnabled != null)
+    dualVersionModeEnabled = !!next.dualVersionModeEnabled;
+  if (Object.prototype.hasOwnProperty.call(next, "dualVersionSecondaryId"))
+    dualVersionSecondaryId = next.dualVersionSecondaryId || null;
+}
+
+function updateSettingsTargetControl() {
+  const value = normalizeSettingsTargetTab(settingsTargetTab);
+  const activeKey = mediaSettingsTargetActive
+    ? "media"
+    : value === "follow"
+      ? getEffectiveSettingsTargetTab(value)
+      : value;
+  ["follow", "bible", "songs", "schedule", "media"].forEach((key) => {
+    const btn = document.getElementById(`settings-target-${key}`);
+    if (btn) btn.classList.toggle("active", key === activeKey);
+  });
+  if (typeof refreshSettingsTabVisibility === "function") {
+    refreshSettingsTabVisibility(getEffectiveSettingsTargetTab());
+  }
+}
+
+function refreshMediaSettingsTabVisibility() {
+  document.querySelectorAll(".sm-sidebar-item[data-sm-tab]").forEach((item) => {
+    const tabId = item.dataset.smTab;
+    item.style.display = MEDIA_SETTINGS_TABS.has(tabId) ? "" : "none";
+  });
+  const activeTabId = document.querySelector(
+    ".sm-sidebar-item.active[data-sm-tab]",
+  )?.dataset?.smTab;
+  switchSettingsTab(
+    MEDIA_SETTINGS_TABS.has(activeTabId) ? activeTabId : "media",
+  );
+  if (
+    window.bspMedia &&
+    typeof window.bspMedia.syncSettingsForm === "function"
+  ) {
+    window.bspMedia.syncSettingsForm();
+  }
+}
+
+function refreshSettingsTabVisibility(
+  targetTab = getEffectiveSettingsTargetTab(),
+) {
+  if (mediaSettingsTargetActive) {
+    refreshMediaSettingsTabVisibility();
+    return;
+  }
+  const effectiveTarget = SETTINGS_TARGET_TABS.includes(targetTab)
+    ? targetTab
+    : "bible";
+  const tabSpecificMap = {
+    song: "songs",
+    bible: "bible",
+    setlist: "schedule",
+  };
+  const setlistHiddenTabs = new Set([
+    "fullscreen",
+    "lowerthird",
+    "typography",
+    "background",
+  ]);
+  document.querySelectorAll(".sm-sidebar-item[data-sm-tab]").forEach((item) => {
+    const tabId = item.dataset.smTab;
+    if (tabId === "media") {
+      item.style.display = "none";
+      return;
     }
-
-    function extractTypographySnapshot(settings) {
-      if (!settings || typeof settings !== 'object') return null;
-      const snapshot = {};
-      TYPOGRAPHY_SETTINGS_KEYS.forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(settings, key)) {
-          snapshot[key] = settings[key];
-        }
-      });
-      return Object.keys(snapshot).length ? snapshot : null;
+    if (effectiveTarget === "schedule" && setlistHiddenTabs.has(tabId)) {
+      item.style.display = "none";
+      return;
     }
-
-    function persistTypographyState() {
-      if (!stateReady || isRestoringBackup) {
-        pendingTypographyPersist = true;
-        return;
-      }
-      const snapshot = getTypographySnapshot();
-      if (!snapshot) return;
-      const payload = { key: 'typographySettings', value: snapshot, updatedAt: Date.now() };
-      idbPut(STORE_STATE, payload).catch(() => {});
+    if (!Object.prototype.hasOwnProperty.call(tabSpecificMap, tabId)) {
+      if (tabId !== "customstyle") item.style.display = "";
+      return;
     }
+    item.style.display =
+      tabSpecificMap[tabId] === effectiveTarget ? "" : "none";
+  });
+  const activeSidebarItem = document.querySelector(
+    ".sm-sidebar-item.active[data-sm-tab]",
+  );
+  const activeTabId =
+    activeSidebarItem?.dataset?.smTab ||
+    document.querySelector(".sm-tab-panel.active")?.dataset?.smPanel ||
+    "fullscreen";
+  const visibleSidebarItems = Array.from(
+    document.querySelectorAll(".sm-sidebar-item[data-sm-tab]"),
+  ).filter((item) => item.style.display !== "none");
+  const nextTabId = visibleSidebarItems.some(
+    (item) => item.dataset.smTab === activeTabId,
+  )
+    ? activeTabId
+    : visibleSidebarItems[0]?.dataset?.smTab || "fullscreen";
+  const isBibleTarget = effectiveTarget === "bible";
+  const isSongsTarget = effectiveTarget === "songs";
+  const setDisplay = (id, show) => {
+    const el = document.getElementById(id);
+    if (el) el.style.display = show ? "" : "none";
+  };
+  const setText = (id, text) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = text;
+  };
+  setDisplay("full-ref-font-field", isBibleTarget);
+  setDisplay("full-ref-align-field", isBibleTarget);
+  setDisplay("full-ref-position-field", isBibleTarget);
+  setDisplay("lt-ref-font-field", isBibleTarget);
+  setDisplay("lt-bible-verse-align-row", isBibleTarget);
+  setDisplay("ref-color-field", !isSongsTarget);
+  setDisplay("ref-shadow-field", !isSongsTarget);
+  setDisplay("ref-bg-toggle-row", !isSongsTarget);
+  setDisplay("ref-bg-color-row", !isSongsTarget);
+  setDisplay("full-song-transform-field", isSongsTarget);
+  setDisplay("lt-song-transform-field", isSongsTarget);
+  setDisplay("full-ref-transform-field", isBibleTarget);
+  setDisplay("lt-ref-transform-field", isBibleTarget);
+  setText(
+    "full-content-font-label",
+    isBibleTarget
+      ? "Verse Font Size (pt)"
+      : isSongsTarget
+        ? "Song Font Size (pt)"
+        : "Font Size (pt)",
+  );
+  setText(
+    "lt-content-font-label",
+    isBibleTarget
+      ? "Verse Font Size (pt)"
+      : isSongsTarget
+        ? "Song Font Size (pt)"
+        : "Font Size (pt)",
+  );
+  setText(
+    "lt-primary-align-label",
+    isBibleTarget ? "Ref. X Align" : isSongsTarget ? "Text X Align" : "X Align",
+  );
+  setText(
+    "full-content-align-label",
+    isBibleTarget ? "Verse X Align" : "Text X Align",
+  );
+  setText(
+    "verse-shadow-label",
+    isBibleTarget
+      ? "Verse Shadow"
+      : isSongsTarget
+        ? "Song Shadow"
+        : "Verse/Song Shadow",
+  );
+  if (nextTabId) switchSettingsTab(nextTabId);
+}
 
-    function schedulePersistTypography() {
-      if (!stateReady || isRestoringBackup) {
-        pendingTypographyPersist = true;
-        return;
-      }
-      clearTimeout(typographySaveTimer);
-      typographySaveTimer = setTimeout(() => {
-        persistTypographyState();
-      }, 500);
-    }
+function applyProjectionSettingsSnapshot(profile, opts = {}) {
+  const targetTab = SETTINGS_TARGET_TABS.includes(opts.tab)
+    ? opts.tab
+    : sidebarTab;
+  const next = normalizeProjectionSettingsSnapshot(
+    profile,
+    captureProjectionSettingsSnapshot(),
+  );
+  if (next.fontFamily) {
+    const fontFamilyEl = document.getElementById("font-family");
+    if (fontFamilyEl) fontFamilyEl.value = next.fontFamily;
+    if (typeof renderFontFamilyOptions === "function")
+      renderFontFamilyOptions(next.fontFamily);
+  }
+  if (next.fontWeight && document.getElementById("font-weight"))
+    document.getElementById("font-weight").value = next.fontWeight;
+  if (next.fontSizeFull != null && document.getElementById("font-size-val"))
+    document.getElementById("font-size-val").value = next.fontSizeFull;
+  if (typeof next.fullTextTransform !== "undefined")
+    updateFullTextTransformValue(next.fullTextTransform);
+  if (typeof next.fullRefTextTransform !== "undefined")
+    updateReferenceTextTransformValue("full", next.fullRefTextTransform);
+  ltFontSongs =
+    next.ltFontSongs != null ? Number(next.ltFontSongs) : ltFontSongs;
+  ltFontBible =
+    next.ltFontBible != null ? Number(next.ltFontBible) : ltFontBible;
+  ltFontCustom =
+    next.ltFontCustom != null ? Number(next.ltFontCustom) : ltFontCustom;
+  if (next.refFontSize != null && document.getElementById("ref-font-size-val"))
+    document.getElementById("ref-font-size-val").value = next.refFontSize;
+  if (
+    next.ltRefFontSize != null &&
+    document.getElementById("ref-font-size-lt-val")
+  )
+    document.getElementById("ref-font-size-lt-val").value = next.ltRefFontSize;
+  ltRefFontSize = Number(next.ltRefFontSize || ltRefFontSize);
+  if (
+    next.lineHeightFull != null &&
+    document.getElementById("line-height-full")
+  )
+    document.getElementById("line-height-full").value = next.lineHeightFull;
+  if (next.lineHeightLT != null && document.getElementById("line-height-lt"))
+    document.getElementById("line-height-lt").value = next.lineHeightLT;
+  if (next.padLRFull != null && document.getElementById("pad-lr-full")) {
+    document.getElementById("pad-lr-full").value = next.padLRFull;
+  } else if (next.padLR != null && document.getElementById("pad-lr-full")) {
+    document.getElementById("pad-lr-full").value = next.padLR;
+  }
+  if (next.padLRLT != null && document.getElementById("pad-lr-lt")) {
+    document.getElementById("pad-lr-lt").value = next.padLRLT;
+  } else if (next.padLR != null && document.getElementById("pad-lr-lt")) {
+    document.getElementById("pad-lr-lt").value = next.padLR;
+  }
+  if (next.textColor && document.getElementById("text-color"))
+    document.getElementById("text-color").value = next.textColor;
+  if (next.textColor && document.getElementById("text-color-hex"))
+    document.getElementById("text-color-hex").value = String(
+      next.textColor,
+    ).toUpperCase();
+  if (next.refColor && document.getElementById("ref-color"))
+    document.getElementById("ref-color").value = next.refColor;
+  if (next.refColor && document.getElementById("ref-color-hex"))
+    document.getElementById("ref-color-hex").value = String(
+      next.refColor,
+    ).toUpperCase();
+  if (next.refBgColor && document.getElementById("ref-bg-color"))
+    document.getElementById("ref-bg-color").value = next.refBgColor;
+  if (next.refBgColor && document.getElementById("ref-bg-color-hex"))
+    document.getElementById("ref-bg-color-hex").value = String(
+      next.refBgColor,
+    ).toUpperCase();
+  if (next.linesPerPage != null)
+    linesPerPage = Math.max(
+      1,
+      Math.min(
+        getMaxLinesForCurrentTab(targetTab),
+        Number(next.linesPerPage) || 1,
+      ),
+    );
+  if (next.activeRatio)
+    activeRatio = next.activeRatio === "16-9" ? "16-9" : "full";
+  if (typeof next.ltTextTransform !== "undefined")
+    updateLtTextTransformValue(next.ltTextTransform, { markUser: true });
+  if (typeof next.ltRefTextTransform !== "undefined")
+    updateReferenceTextTransformValue("lt", next.ltRefTextTransform);
+  if (next.showVersion != null && document.getElementById("show-version"))
+    document.getElementById("show-version").checked = !!next.showVersion;
+  if (next.showVerseNos != null && document.getElementById("show-verse-nos"))
+    document.getElementById("show-verse-nos").checked = !!next.showVerseNos;
+  if (
+    next.shortenBibleVersions != null &&
+    document.getElementById("shorten-bible-versions")
+  )
+    document.getElementById("shorten-bible-versions").checked =
+      !!next.shortenBibleVersions;
+  if (
+    next.shortenBibleBooks != null &&
+    document.getElementById("shorten-bible-books")
+  )
+    document.getElementById("shorten-bible-books").checked =
+      !!next.shortenBibleBooks;
+  autoAdjustLtHeight =
+    next.autoAdjustLtHeight != null
+      ? !!next.autoAdjustLtHeight
+      : autoAdjustLtHeight;
+  if (document.getElementById("auto-adjust-lt-height"))
+    document.getElementById("auto-adjust-lt-height").checked =
+      autoAdjustLtHeight;
+  if (next.autoResizeFull && document.getElementById("auto-resize-full"))
+    document.getElementById("auto-resize-full").value = next.autoResizeFull;
+  if (next.autoResizeLT && document.getElementById("auto-resize-lt"))
+    document.getElementById("auto-resize-lt").value = next.autoResizeLT;
+  if (next.refPositionFull && document.getElementById("ref-position-full"))
+    document.getElementById("ref-position-full").value = next.refPositionFull;
+  if (typeof renderLtPresetOptions === "function")
+    renderLtPresetOptions(next.ltPresetSelection || "default", targetTab);
+  if (typeof updateLtPresetUpdateLiveState === "function") {
+    updateLtPresetUpdateLiveState(next.ltPresetUpdatesLive !== false);
+  }
+  if (next.ltWidthPct != null && document.getElementById("lt-width-pct"))
+    document.getElementById("lt-width-pct").value = next.ltWidthPct;
+  if (next.ltWidthPct != null && document.getElementById("lt-width-pct-value"))
+    document.getElementById("lt-width-pct-value").textContent =
+      `${next.ltWidthPct}%`;
+  if (next.ltScalePct != null && document.getElementById("lt-scale-pct"))
+    document.getElementById("lt-scale-pct").value = next.ltScalePct;
+  if (next.ltScalePct != null && document.getElementById("lt-scale-pct-value"))
+    document.getElementById("lt-scale-pct-value").textContent =
+      `${next.ltScalePct}%`;
+  if (next.ltOffsetX != null && document.getElementById("lt-offset-x"))
+    document.getElementById("lt-offset-x").value = next.ltOffsetX;
+  if (next.ltOffsetY != null && document.getElementById("lt-offset-y"))
+    document.getElementById("lt-offset-y").value = next.ltOffsetY;
+  if (
+    next.ltBorderRadius != null &&
+    document.getElementById("lt-border-radius")
+  )
+    document.getElementById("lt-border-radius").value = next.ltBorderRadius;
+  if (
+    next.ltBorderRadius != null &&
+    document.getElementById("lt-border-radius-value")
+  )
+    document.getElementById("lt-border-radius-value").textContent =
+      `${next.ltBorderRadius}px`;
+  if (next.bgType && document.getElementById("bg-type"))
+    document.getElementById("bg-type").value = next.bgType;
+  if (next.bgImageSource && document.getElementById("bg-image-source"))
+    document.getElementById("bg-image-source").value = next.bgImageSource;
+  if (
+    Object.prototype.hasOwnProperty.call(next, "bgImageUrl") &&
+    document.getElementById("bg-image-url")
+  )
+    document.getElementById("bg-image-url").value = next.bgImageUrl || "";
+  if (Object.prototype.hasOwnProperty.call(next, "bgUploadDataUrl"))
+    bgUploadDataUrl = next.bgUploadDataUrl || null;
+  if (next.bgVideoSource && document.getElementById("bg-video-source"))
+    document.getElementById("bg-video-source").value = next.bgVideoSource;
+  if (
+    Object.prototype.hasOwnProperty.call(next, "bgVideoUrl") &&
+    document.getElementById("bg-video-url")
+  )
+    document.getElementById("bg-video-url").value = next.bgVideoUrl || "";
+  if (Object.prototype.hasOwnProperty.call(next, "bgVideoUploadDataUrl"))
+    bgVideoUploadDataUrl = next.bgVideoUploadDataUrl || null;
+  if (next.bgVideoLoop != null && document.getElementById("bg-video-loop"))
+    document.getElementById("bg-video-loop").checked = !!next.bgVideoLoop;
+  if (next.bgVideoSpeed != null && document.getElementById("bg-video-speed"))
+    document.getElementById("bg-video-speed").value = next.bgVideoSpeed;
+  if (next.bgColor && document.getElementById("bg-color-quick"))
+    document.getElementById("bg-color-quick").value = next.bgColor;
+  if (next.bgGradientShadow && document.getElementById("bg-color-shadow")) {
+    bgGradientShadow = next.bgGradientShadow;
+    document.getElementById("bg-color-shadow").value = next.bgGradientShadow;
+  }
+  if (
+    next.bgGradientHighlight &&
+    document.getElementById("bg-color-highlight")
+  ) {
+    bgGradientHighlight = next.bgGradientHighlight;
+    document.getElementById("bg-color-highlight").value =
+      next.bgGradientHighlight;
+  }
+  if (typeof next.bgMode !== "undefined" && typeof setBgMode === "function") {
+    setBgMode(next.bgMode, { silent: true });
+  } else if (typeof updateBgModeUi === "function") {
+    updateBgModeUi();
+  }
+  if (next.bgBlur != null && document.getElementById("bg-blur"))
+    document.getElementById("bg-blur").value = next.bgBlur;
+  if (next.bgEdgeFix != null && document.getElementById("bg-edge-fix"))
+    document.getElementById("bg-edge-fix").value = next.bgEdgeFix
+      ? "on"
+      : "off";
+  if (next.bgOpacityFull != null)
+    bgOpacityFull = Math.max(0, Math.min(100, Number(next.bgOpacityFull) || 0));
+  if (next.bgOpacityLT != null)
+    bgOpacityLT = Math.max(0, Math.min(100, Number(next.bgOpacityLT) || 0));
+  if (next.bgY != null && document.getElementById("bg-y"))
+    document.getElementById("bg-y").value = next.bgY;
+  if (next.bgToggle != null && document.getElementById("bg-toggle"))
+    document.getElementById("bg-toggle").checked = !!next.bgToggle;
+  if (
+    next.animateBgTransitions != null &&
+    document.getElementById("animate-bg-transitions")
+  )
+    document.getElementById("animate-bg-transitions").checked =
+      !!next.animateBgTransitions;
+  if (
+    next.bgGradientAngle != null &&
+    document.getElementById("bg-gradient-angle")
+  )
+    document.getElementById("bg-gradient-angle").value = next.bgGradientAngle;
+  if (document.getElementById("bg-upload-hint")) {
+    document.getElementById("bg-upload-hint").innerText = bgUploadDataUrl
+      ? t("settings_image_selected")
+      : t("settings_no_image_selected");
+  }
+  if (document.getElementById("bg-video-upload-hint")) {
+    document.getElementById("bg-video-upload-hint").innerText =
+      bgVideoUploadDataUrl
+        ? t("settings_video_selected")
+        : t("settings_no_video_selected");
+  }
+  if (typeof handleBgTypeChange === "function") handleBgTypeChange();
+  if (typeof syncBgOpacitySlider === "function") syncBgOpacitySlider();
+  fullRefHAlign = next.hAlignFullRef || fullRefHAlign;
+  fullHAlign = next.hAlignFull || fullHAlign;
+  fullVAlign = next.vAlignFull || fullVAlign;
+  ltHAlignSongs = next.hAlignLTSongs || ltHAlignSongs;
+  ltVAlignSongs = next.vAlignLTSongs || ltVAlignSongs;
+  ltAnchorMode = next.ltAnchorMode === "top" ? "top" : "bottom";
+  ltHAlignBible = next.hAlignLTBible || ltHAlignBible;
+  ltVAlignBible = next.vAlignLTBible || ltVAlignBible;
+  ltHAlignBibleVerse = next.hAlignLTBibleVerse || ltHAlignBibleVerse;
+  if (next.refBgEnabled != null)
+    setRefBgEnabled(!!next.refBgEnabled, { silent: true });
+  if (next.referenceShadowEnabled != null)
+    setReferenceShadowEnabled(!!next.referenceShadowEnabled, { silent: true });
+  if (next.verseShadowEnabled != null)
+    setVerseShadowEnabled(!!next.verseShadowEnabled, { silent: true });
+  if (next.referenceTextCapitalized != null)
+    setReferenceCapitalized(!!next.referenceTextCapitalized, { silent: true });
+  if (next.dualVersionModeEnabled != null)
+    setDualVersionModeEnabled(!!next.dualVersionModeEnabled, { silent: true });
+  if (Object.prototype.hasOwnProperty.call(next, "dualVersionSecondaryId"))
+    setDualVersionSecondaryId(next.dualVersionSecondaryId || null, {
+      silent: true,
+    });
+  setLtFontInputValue(getEffectiveLtFont());
+  updateFullAlignButtons();
+  updateLtAlignButtons();
+  if (typeof refreshSliderPaint === "function") {
+    refreshSliderPaint([
+      "line-height-full",
+      "line-height-lt",
+      "pad-lr-full",
+      "pad-lr-lt",
+      "lt-width-pct",
+      "lt-scale-pct",
+      "lt-border-radius",
+      "bg-blur",
+      "bg-opacity-full",
+      "bg-opacity-lt",
+      "bg-y",
+      "bg-gradient-angle",
+      "bg-video-speed",
+    ]);
+  }
+  if (typeof syncLtPresetSelectionToCurrentValues === "function") {
+    syncLtPresetSelectionToCurrentValues(targetTab);
+  }
+  document
+    .querySelectorAll("#line-picker .seg-btn")
+    .forEach((b) =>
+      b.classList.toggle("active", b.id === "line-" + linesPerPage),
+    );
+  document
+    .getElementById("ratio-full")
+    ?.classList.toggle("active", activeRatio === "full");
+  document
+    .getElementById("ratio-lt")
+    ?.classList.toggle("active", activeRatio === "16-9");
+  document.getElementById("ratio-custom")?.classList.toggle("active", false);
+  updateLinePickerAvailability();
+  updateCustomModeAvailability();
+  updateTextEditorModeAvailability();
+  if (opts.triggerChange && typeof onAnyControlChange === "function")
+    onAnyControlChange();
+}
 
-    function getModeSettingsSnapshot() {
-      const fullSizeEl = document.getElementById('font-size-val');
-      if (!fullSizeEl) return null;
-      return {
-        fontSizeFull: fullSizeEl.value,
-        lineHeightFull: document.getElementById('line-height-full')?.value,
-        fullTextTransform: document.getElementById('full-text-transform')?.value || fullTextTransform,
-        autoResizeFull: document.getElementById('auto-resize-full')?.value,
-        autoResizeLT: document.getElementById('auto-resize-lt')?.value,
-        refPositionFull: document.getElementById('ref-position-full')?.value,
-        hAlignFullRef: fullRefHAlign,
-        hAlignFull: fullHAlign,
-        vAlignFull: fullVAlign,
-        ltFontSongs,
-        ltFontBible,
-        ltFontCustom,
-        lineHeightLT: document.getElementById('line-height-lt')?.value,
-        hAlignLTSongs: ltHAlignSongs,
-        vAlignLTSongs: ltVAlignSongs,
-        ltAnchorMode,
-        hAlignLTBible: ltHAlignBible,
-        vAlignLTBible: ltVAlignBible,
-        hAlignLTBibleVerse: ltHAlignBibleVerse,
-        autoAdjustLtHeight: document.getElementById('auto-adjust-lt-height')?.checked,
-        refBgColor: document.getElementById('ref-bg-color')?.value,
-        refBgEnabled: refBgEnabled,
-        ltRefFontSize: document.getElementById('ref-font-size-lt-val')?.value,
-        referenceShadowEnabled: referenceShadowEnabled,
-        verseShadowEnabled: verseShadowEnabled,
-        referenceTextCapitalized: document.getElementById('capitalize-ref-text')?.checked,
-        showVersion: document.getElementById('show-version')?.checked,
-        shortenBibleVersions: document.getElementById('shorten-bible-versions')?.checked,
-        shortenBibleBooks: document.getElementById('shorten-bible-books')?.checked,
-        showVerseNos: document.getElementById('show-verse-nos')?.checked,
-        versionSwitchUpdatesLive: document.getElementById('version-switch-updates-live')?.checked,
-        dualVersionModeEnabled: dualVersionModeEnabled,
-        dualVersionSecondaryId: dualVersionSecondaryId
-      };
-    }
+function applyProjectionSettingsProfileForTab(tab, opts = {}) {
+  if (!SETTINGS_TARGET_TABS.includes(tab)) return false;
+  applyProjectionSettingsSnapshot(getProjectionSettingsSnapshotForTab(tab), {
+    ...opts,
+    tab,
+  });
+  return true;
+}
 
-    function applyModeSettingsSnapshot(target, snapshot) {
-      if (!target || !snapshot) return;
-      MODE_SETTINGS_KEYS.forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
-          target[key] = snapshot[key];
-        }
-      });
-    }
+function setMediaSettingsTargetActive(active) {
+  const next = !!active;
+  if (next === mediaSettingsTargetActive) return;
+  if (next)
+    saveProjectionSettingsProfileForTab(getEffectiveSettingsTargetTab());
+  mediaSettingsTargetActive = next;
+  updateSettingsTargetControl();
+}
 
-    function extractModeSettingsSnapshot(settings) {
-      if (!settings || typeof settings !== 'object') return null;
-      const snapshot = {};
-      MODE_SETTINGS_KEYS.forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(settings, key)) {
-          snapshot[key] = settings[key];
-        }
-      });
-      return Object.keys(snapshot).length ? snapshot : null;
-    }
+function setSettingsTargetTab(target, opts = {}) {
+  saveProjectionSettingsProfileForTab(getEffectiveSettingsTargetTab());
+  mediaSettingsTargetActive = false;
+  settingsTargetTab = normalizeSettingsTargetTab(target);
+  updateSettingsTargetControl();
+  applyProjectionSettingsProfileForTab(getEffectiveSettingsTargetTab(), {
+    triggerChange: !!opts.triggerChange,
+  });
+  const isLockedInactiveTarget =
+    settingsTargetTab !== "follow" &&
+    getEffectiveSettingsTargetTab() !== sidebarTab;
+  if (isLockedInactiveTarget) {
+    applyProjectionRuntimeSnapshot(
+      getProjectionSettingsSnapshotForTab(sidebarTab),
+    );
+  }
+  if (!opts.silent) saveToStorageDebounced();
+}
 
-    const PROJECTION_SETTINGS_PROFILE_KEYS = Array.from(new Set([
-      'fontFamily',
-      'fontWeight',
-      'fontSizeFull',
-      'fullTextTransform',
-      'ltFontSongs',
-      'ltFontBible',
-      'ltFontCustom',
-      'refFontSize',
-      'lineHeightFull',
-      'lineHeightLT',
-      'textColor',
-      'refColor',
-      'refBgColor',
-      'bgType',
-      'bgImageSource',
-      'bgImageUrl',
-      'bgUploadDataUrl',
-      'bgVideoSource',
-      'bgVideoUrl',
-      'bgVideoUploadDataUrl',
-      'bgVideoLoop',
-      'bgVideoSpeed',
-      'bgMode',
-      'bgColor',
-      'bgGradientShadow',
-      'bgGradientHighlight',
-      'bgBlur',
-      'bgEdgeFix',
-      'bgOpacity',
-      'bgOpacityFull',
-      'bgOpacityLT',
-      'bgY',
-      'bgToggle',
-      'animateBgTransitions',
-      'bgGradientAngle',
-      'ltRefFontSize',
-      'linesPerPage',
-      'activeRatio',
-      'ltTextTransform',
-      'fullRefTextTransform',
-      'ltRefTextTransform',
-      'showVersion',
-      'showVerseNos',
-      'shortenBibleVersions',
-      'shortenBibleBooks',
-      'autoAdjustLtHeight',
-      'autoResizeFull',
-      'autoResizeLT',
-      'refPositionFull',
-      'ltWidthPct',
-      'ltScalePct',
-      'ltOffsetX',
-      'ltOffsetY',
-      'ltBorderRadius',
-      'padLRFull',
-      'padLRLT',
-      'hAlignFullRef',
-      'hAlignFull',
-      'vAlignFull',
-      'hAlignLTSongs',
-      'vAlignLTSongs',
-      'ltAnchorMode',
-      'hAlignLTBible',
-      'vAlignLTBible',
-      'hAlignLTBibleVerse',
-      'referenceShadowEnabled',
-      'verseShadowEnabled',
-      'referenceTextCapitalized',
-      'refBgEnabled',
-      'ltPresetSelection',
-      'ltPresetUpdatesLive',
-      'dualVersionModeEnabled',
-      'dualVersionSecondaryId'
-    ]));
-    const SETTINGS_TARGET_TABS = ['bible', 'songs', 'schedule'];
-    // Media is a settings target but not a projection-settings profile: it keeps its own
-    // defaults (see media-workspace.js) and must not read or write typography profiles.
-    const MEDIA_SETTINGS_TABS = new Set(['media', 'presets', 'themes', 'updates', 'feedback']);
-    let mediaSettingsTargetActive = false;
+function handleSettingsTargetChange(target) {
+  if (target === "media") {
+    setMediaSettingsTargetActive(true);
+    return;
+  }
+  setSettingsTargetTab(target || "bible");
+}
 
-    function normalizeSettingsTargetTab(value) {
-      return (value === 'follow' || SETTINGS_TARGET_TABS.includes(value)) ? value : 'follow';
-    }
+function getSetlistSettingsSnapshot() {
+  const autoGoLiveToggle = document.getElementById("setlist-auto-go-live");
+  const advancePreviewToggle = document.getElementById(
+    "setlist-advance-preview",
+  );
+  return {
+    autoGoLiveOnSelect: autoGoLiveToggle
+      ? !!autoGoLiveToggle.checked
+      : !!setlistSettings.autoGoLiveOnSelect,
+    advancePreviewAfterLive: advancePreviewToggle
+      ? !!advancePreviewToggle.checked
+      : !!setlistSettings.advancePreviewAfterLive,
+  };
+}
 
-    function getEffectiveSettingsTargetTab(target = settingsTargetTab) {
-      const normalized = normalizeSettingsTargetTab(target);
-      return normalized === 'follow' ? (sidebarTab || 'bible') : normalized;
-    }
+function applySetlistSettingsSnapshot(raw) {
+  const source = raw && typeof raw === "object" ? raw : {};
+  setlistSettings = {
+    autoGoLiveOnSelect: source.autoGoLiveOnSelect === true,
+    advancePreviewAfterLive: source.advancePreviewAfterLive !== false,
+  };
+  const autoGoLiveToggle = document.getElementById("setlist-auto-go-live");
+  if (autoGoLiveToggle)
+    autoGoLiveToggle.checked = !!setlistSettings.autoGoLiveOnSelect;
+  const advancePreviewToggle = document.getElementById(
+    "setlist-advance-preview",
+  );
+  if (advancePreviewToggle)
+    advancePreviewToggle.checked = !!setlistSettings.advancePreviewAfterLive;
+  return { ...setlistSettings };
+}
 
-    function captureProjectionSettingsSnapshot() {
-      return {
-        ...(getTypographySnapshot() || {}),
-        ...(getBackgroundSnapshot() || {}),
-        fontSizeFull: document.getElementById('font-size-val')?.value,
-        ltFontSongs, ltFontBible, ltFontCustom,
-        refFontSize: document.getElementById('ref-font-size-val')?.value,
-        ltRefFontSize: document.getElementById('ref-font-size-lt-val')?.value,
-        lineHeightFull: document.getElementById('line-height-full')?.value,
-        lineHeightLT: document.getElementById('line-height-lt')?.value,
-        textColor: document.getElementById('text-color')?.value,
-        refColor: document.getElementById('ref-color')?.value,
-        refBgColor: document.getElementById('ref-bg-color')?.value,
-        linesPerPage, activeRatio,
-        fullTextTransform: document.getElementById('full-text-transform')?.value || fullTextTransform,
-        ltTextTransform: document.getElementById('lt-text-transform')?.value || ltTextTransform || 'uppercase',
-        fullRefTextTransform: document.getElementById('full-ref-text-transform')?.value || fullRefTextTransform || 'uppercase',
-        ltRefTextTransform: document.getElementById('lt-ref-text-transform')?.value || ltRefTextTransform || 'uppercase',
-        showVersion: document.getElementById('show-version')?.checked,
-        showVerseNos: document.getElementById('show-verse-nos')?.checked,
-        shortenBibleVersions: document.getElementById('shorten-bible-versions')?.checked,
-        shortenBibleBooks: document.getElementById('shorten-bible-books')?.checked,
-        autoAdjustLtHeight: document.getElementById('auto-adjust-lt-height')?.checked,
-        autoResizeFull: document.getElementById('auto-resize-full')?.value,
-        autoResizeLT: document.getElementById('auto-resize-lt')?.value,
-        refPositionFull: document.getElementById('ref-position-full')?.value,
-        ltPresetSelection: document.getElementById('lt-preset-select')?.value || 'default',
-        ltPresetUpdatesLive: document.getElementById('lt-preset-update-live')?.value !== 'false',
-        ltWidthPct: document.getElementById('lt-width-pct')?.value,
-        ltScalePct: document.getElementById('lt-scale-pct')?.value,
-        ltOffsetX: document.getElementById('lt-offset-x')?.value,
-        ltOffsetY: document.getElementById('lt-offset-y')?.value,
-        ltBorderRadius: document.getElementById('lt-border-radius')?.value,
-        padLRFull: document.getElementById('pad-lr-full')?.value ?? 5,
-        padLRLT: document.getElementById('pad-lr-lt')?.value ?? 5,
-        hAlignFullRef: fullRefHAlign, hAlignFull: fullHAlign, vAlignFull: fullVAlign,
-        hAlignLTSongs: ltHAlignSongs, vAlignLTSongs: ltVAlignSongs, ltAnchorMode,
-        hAlignLTBible: ltHAlignBible, vAlignLTBible: ltVAlignBible, hAlignLTBibleVerse: ltHAlignBibleVerse,
-        referenceShadowEnabled, verseShadowEnabled,
-        referenceTextCapitalized: document.getElementById('capitalize-ref-text')?.checked,
-        refBgEnabled, dualVersionModeEnabled, dualVersionSecondaryId
-      };
-    }
-
-    function normalizeProjectionSettingsSnapshot(raw, fallback = {}) {
-      const next = { ...fallback };
-      const source = (raw && typeof raw === 'object') ? raw : {};
-      PROJECTION_SETTINGS_PROFILE_KEYS.forEach((key) => {
-        if (Object.prototype.hasOwnProperty.call(source, key) && source[key] != null) next[key] = source[key];
-      });
-      return next;
-    }
-
-    function createDefaultProjectionSettingsProfiles(seed = null) {
-      const base = normalizeProjectionSettingsSnapshot(seed || captureProjectionSettingsSnapshot(), {});
-      return {
-        bible: {
-          ...base,
-          ltPresetSelection: 'rounded-card',
-          autoResizeLT: 'shrink',
-          lineHeightLT: 1.1,
-          padLRLT: 5,
-          ltWidthPct: 100,
-          ltScalePct: 80,
-          ltOffsetX: 0,
-          ltOffsetY: 25,
-          ltBorderRadius: 23,
-          autoAdjustLtHeight: true,
-          hAlignLTBible: 'center',
-          vAlignLTBible: 'middle',
-          hAlignLTBibleVerse: 'center',
-          ltAnchorMode: 'bottom',
-          bgOpacityFull: 100,
-          bgOpacityLT: 100
-        },
-        songs: {
-          ...base,
-          ltWidthPct: 60,
-          ltOffsetX: 0,
-          ltOffsetY: 50,
-          bgOpacityFull: 100,
-          bgOpacityLT: 100
-        },
-        schedule: { ...base }
-      };
-    }
-
-    function ensureProjectionSettingsProfiles(seed = null) {
-      if (!projectionSettingsProfilesByTab || typeof projectionSettingsProfilesByTab !== 'object') {
-        projectionSettingsProfilesByTab = createDefaultProjectionSettingsProfiles(seed);
-      }
-      const defaults = createDefaultProjectionSettingsProfiles(seed);
-      SETTINGS_TARGET_TABS.forEach((tab) => {
-        projectionSettingsProfilesByTab[tab] = normalizeProjectionSettingsSnapshot(projectionSettingsProfilesByTab[tab], defaults[tab]);
-      });
-      return projectionSettingsProfilesByTab;
-    }
-
-    function loadProjectionSettingsProfilesFromUi(ui) {
-      const seed = normalizeProjectionSettingsSnapshot(ui || {}, captureProjectionSettingsSnapshot());
-      projectionSettingsProfilesByTab = createDefaultProjectionSettingsProfiles(seed);
-      const source = (ui && ui.projectionSettingsProfiles && typeof ui.projectionSettingsProfiles === 'object') ? ui.projectionSettingsProfiles : {};
-      SETTINGS_TARGET_TABS.forEach((tab) => {
-        projectionSettingsProfilesByTab[tab] = normalizeProjectionSettingsSnapshot(source[tab], projectionSettingsProfilesByTab[tab]);
-      });
-      settingsTargetTab = normalizeSettingsTargetTab(ui?.settingsTargetTab);
-      return projectionSettingsProfilesByTab;
-    }
-
-    function saveProjectionSettingsProfileForTab(tab = getEffectiveSettingsTargetTab()) {
-      if (!SETTINGS_TARGET_TABS.includes(tab)) return null;
-      const profiles = ensureProjectionSettingsProfiles();
-      profiles[tab] = normalizeProjectionSettingsSnapshot(captureProjectionSettingsSnapshot(), profiles[tab]);
-      return profiles[tab];
-    }
-
-    function getProjectionSettingsSnapshotForTab(tab = getEffectiveSettingsTargetTab()) {
-      if (!SETTINGS_TARGET_TABS.includes(tab)) return normalizeProjectionSettingsSnapshot(captureProjectionSettingsSnapshot(), {});
-      const profiles = ensureProjectionSettingsProfiles();
-      return normalizeProjectionSettingsSnapshot(profiles[tab], captureProjectionSettingsSnapshot());
-    }
-
-    function applyProjectionRuntimeSnapshot(profile) {
-      const next = normalizeProjectionSettingsSnapshot(profile, captureProjectionSettingsSnapshot());
-      if (typeof next.fullTextTransform !== 'undefined') fullTextTransform = next.fullTextTransform;
-      if (typeof next.ltTextTransform !== 'undefined') ltTextTransform = next.ltTextTransform;
-      if (typeof next.fullRefTextTransform !== 'undefined') fullRefTextTransform = next.fullRefTextTransform;
-      if (typeof next.ltRefTextTransform !== 'undefined') ltRefTextTransform = next.ltRefTextTransform;
-      if (next.ltFontSongs != null) ltFontSongs = Number(next.ltFontSongs);
-      if (next.ltFontBible != null) ltFontBible = Number(next.ltFontBible);
-      if (next.ltFontCustom != null) ltFontCustom = Number(next.ltFontCustom);
-      if (next.ltRefFontSize != null) ltRefFontSize = Number(next.ltRefFontSize);
-      if (next.linesPerPage != null) linesPerPage = Math.max(1, Math.min(getMaxLinesForCurrentTab(sidebarTab), Number(next.linesPerPage) || 1));
-      if (next.activeRatio) activeRatio = next.activeRatio === '16-9' ? '16-9' : 'full';
-      if (next.autoAdjustLtHeight != null) autoAdjustLtHeight = !!next.autoAdjustLtHeight;
-      fullRefHAlign = next.hAlignFullRef || fullRefHAlign;
-      fullHAlign = next.hAlignFull || fullHAlign;
-      fullVAlign = next.vAlignFull || fullVAlign;
-      ltHAlignSongs = next.hAlignLTSongs || ltHAlignSongs;
-      ltVAlignSongs = next.vAlignLTSongs || ltVAlignSongs;
-      ltAnchorMode = next.ltAnchorMode === 'top' ? 'top' : 'bottom';
-      ltHAlignBible = next.hAlignLTBible || ltHAlignBible;
-      ltVAlignBible = next.vAlignLTBible || ltVAlignBible;
-      ltHAlignBibleVerse = next.hAlignLTBibleVerse || ltHAlignBibleVerse;
-      if (next.refBgEnabled != null) refBgEnabled = !!next.refBgEnabled;
-      if (next.referenceShadowEnabled != null) referenceShadowEnabled = !!next.referenceShadowEnabled;
-      if (next.verseShadowEnabled != null) verseShadowEnabled = !!next.verseShadowEnabled;
-      if (next.referenceTextCapitalized != null) referenceTextCapitalized = !!next.referenceTextCapitalized;
-      if (next.dualVersionModeEnabled != null) dualVersionModeEnabled = !!next.dualVersionModeEnabled;
-      if (Object.prototype.hasOwnProperty.call(next, 'dualVersionSecondaryId')) dualVersionSecondaryId = next.dualVersionSecondaryId || null;
-    }
-
-    function updateSettingsTargetControl() {
-      const value = normalizeSettingsTargetTab(settingsTargetTab);
-        const activeKey = mediaSettingsTargetActive
-          ? 'media'
-          : (value === 'follow' ? getEffectiveSettingsTargetTab(value) : value);
-        ['follow', 'bible', 'songs', 'schedule', 'media'].forEach((key) => {
-        const btn = document.getElementById(`settings-target-${key}`);
-          if (btn) btn.classList.toggle('active', key === activeKey);
-      });
-      if (typeof refreshSettingsTabVisibility === 'function') {
-        refreshSettingsTabVisibility(getEffectiveSettingsTargetTab());
-      }
-    }
-
-    function refreshMediaSettingsTabVisibility() {
-      document.querySelectorAll('.sm-sidebar-item[data-sm-tab]').forEach((item) => {
-        const tabId = item.dataset.smTab;
-        item.style.display = MEDIA_SETTINGS_TABS.has(tabId) ? '' : 'none';
-      });
-      const activeTabId = document.querySelector('.sm-sidebar-item.active[data-sm-tab]')?.dataset?.smTab;
-      switchSettingsTab(MEDIA_SETTINGS_TABS.has(activeTabId) ? activeTabId : 'media');
-      if (window.bspMedia && typeof window.bspMedia.syncSettingsForm === 'function') {
-        window.bspMedia.syncSettingsForm();
-      }
-    }
-
-    function refreshSettingsTabVisibility(targetTab = getEffectiveSettingsTargetTab()) {
-      if (mediaSettingsTargetActive) {
-        refreshMediaSettingsTabVisibility();
-        return;
-      }
-      const effectiveTarget = SETTINGS_TARGET_TABS.includes(targetTab) ? targetTab : 'bible';
-      const tabSpecificMap = {
-        song: 'songs',
-        bible: 'bible',
-        setlist: 'schedule'
-      };
-      const setlistHiddenTabs = new Set(['fullscreen', 'lowerthird', 'typography', 'background']);
-      document.querySelectorAll('.sm-sidebar-item[data-sm-tab]').forEach((item) => {
-        const tabId = item.dataset.smTab;
-        if (tabId === 'media') {
-          item.style.display = 'none';
-          return;
-        }
-        if (effectiveTarget === 'schedule' && setlistHiddenTabs.has(tabId)) {
-          item.style.display = 'none';
-          return;
-        }
-        if (!Object.prototype.hasOwnProperty.call(tabSpecificMap, tabId)) {
-          if (tabId !== 'customstyle') item.style.display = '';
-          return;
-        }
-        item.style.display = (tabSpecificMap[tabId] === effectiveTarget) ? '' : 'none';
-      });
-      const activeSidebarItem = document.querySelector('.sm-sidebar-item.active[data-sm-tab]');
-      const activeTabId = activeSidebarItem?.dataset?.smTab || document.querySelector('.sm-tab-panel.active')?.dataset?.smPanel || 'fullscreen';
-      const visibleSidebarItems = Array.from(document.querySelectorAll('.sm-sidebar-item[data-sm-tab]'))
-        .filter((item) => item.style.display !== 'none');
-      const nextTabId = visibleSidebarItems.some((item) => item.dataset.smTab === activeTabId)
-        ? activeTabId
-        : (visibleSidebarItems[0]?.dataset?.smTab || 'fullscreen');
-      const isBibleTarget = effectiveTarget === 'bible';
-      const isSongsTarget = effectiveTarget === 'songs';
-      const setDisplay = (id, show) => {
-        const el = document.getElementById(id);
-        if (el) el.style.display = show ? '' : 'none';
-      };
-      const setText = (id, text) => {
-        const el = document.getElementById(id);
-        if (el) el.textContent = text;
-      };
-      setDisplay('full-ref-font-field', isBibleTarget);
-      setDisplay('full-ref-align-field', isBibleTarget);
-      setDisplay('full-ref-position-field', isBibleTarget);
-      setDisplay('lt-ref-font-field', isBibleTarget);
-      setDisplay('lt-bible-verse-align-row', isBibleTarget);
-      setDisplay('ref-color-field', !isSongsTarget);
-      setDisplay('ref-shadow-field', !isSongsTarget);
-      setDisplay('ref-bg-toggle-row', !isSongsTarget);
-      setDisplay('ref-bg-color-row', !isSongsTarget);
-      setDisplay('full-song-transform-field', isSongsTarget);
-      setDisplay('lt-song-transform-field', isSongsTarget);
-      setDisplay('full-ref-transform-field', isBibleTarget);
-      setDisplay('lt-ref-transform-field', isBibleTarget);
-      setText('full-content-font-label', isBibleTarget ? 'Verse Font Size (pt)' : (isSongsTarget ? 'Song Font Size (pt)' : 'Font Size (pt)'));
-      setText('lt-content-font-label', isBibleTarget ? 'Verse Font Size (pt)' : (isSongsTarget ? 'Song Font Size (pt)' : 'Font Size (pt)'));
-      setText('lt-primary-align-label', isBibleTarget ? 'Ref. X Align' : (isSongsTarget ? 'Text X Align' : 'X Align'));
-      setText('full-content-align-label', isBibleTarget ? 'Verse X Align' : 'Text X Align');
-      setText('verse-shadow-label', isBibleTarget ? 'Verse Shadow' : (isSongsTarget ? 'Song Shadow' : 'Verse/Song Shadow'));
-      if (nextTabId) switchSettingsTab(nextTabId);
-    }
-
-    function applyProjectionSettingsSnapshot(profile, opts = {}) {
-      const targetTab = SETTINGS_TARGET_TABS.includes(opts.tab) ? opts.tab : sidebarTab;
-      const next = normalizeProjectionSettingsSnapshot(profile, captureProjectionSettingsSnapshot());
-      if (next.fontFamily) {
-        const fontFamilyEl = document.getElementById('font-family');
-        if (fontFamilyEl) fontFamilyEl.value = next.fontFamily;
-        if (typeof renderFontFamilyOptions === 'function') renderFontFamilyOptions(next.fontFamily);
-      }
-      if (next.fontWeight && document.getElementById('font-weight')) document.getElementById('font-weight').value = next.fontWeight;
-      if (next.fontSizeFull != null && document.getElementById('font-size-val')) document.getElementById('font-size-val').value = next.fontSizeFull;
-      if (typeof next.fullTextTransform !== 'undefined') updateFullTextTransformValue(next.fullTextTransform);
-      if (typeof next.fullRefTextTransform !== 'undefined') updateReferenceTextTransformValue('full', next.fullRefTextTransform);
-      ltFontSongs = (next.ltFontSongs != null) ? Number(next.ltFontSongs) : ltFontSongs;
-      ltFontBible = (next.ltFontBible != null) ? Number(next.ltFontBible) : ltFontBible;
-      ltFontCustom = (next.ltFontCustom != null) ? Number(next.ltFontCustom) : ltFontCustom;
-      if (next.refFontSize != null && document.getElementById('ref-font-size-val')) document.getElementById('ref-font-size-val').value = next.refFontSize;
-      if (next.ltRefFontSize != null && document.getElementById('ref-font-size-lt-val')) document.getElementById('ref-font-size-lt-val').value = next.ltRefFontSize;
-      ltRefFontSize = Number(next.ltRefFontSize || ltRefFontSize);
-      if (next.lineHeightFull != null && document.getElementById('line-height-full')) document.getElementById('line-height-full').value = next.lineHeightFull;
-      if (next.lineHeightLT != null && document.getElementById('line-height-lt')) document.getElementById('line-height-lt').value = next.lineHeightLT;
-      if (next.padLRFull != null && document.getElementById('pad-lr-full')) {
-        document.getElementById('pad-lr-full').value = next.padLRFull;
-      } else if (next.padLR != null && document.getElementById('pad-lr-full')) {
-        document.getElementById('pad-lr-full').value = next.padLR;
-      }
-      if (next.padLRLT != null && document.getElementById('pad-lr-lt')) {
-        document.getElementById('pad-lr-lt').value = next.padLRLT;
-      } else if (next.padLR != null && document.getElementById('pad-lr-lt')) {
-        document.getElementById('pad-lr-lt').value = next.padLR;
-      }
-      if (next.textColor && document.getElementById('text-color')) document.getElementById('text-color').value = next.textColor;
-      if (next.textColor && document.getElementById('text-color-hex')) document.getElementById('text-color-hex').value = String(next.textColor).toUpperCase();
-      if (next.refColor && document.getElementById('ref-color')) document.getElementById('ref-color').value = next.refColor;
-      if (next.refColor && document.getElementById('ref-color-hex')) document.getElementById('ref-color-hex').value = String(next.refColor).toUpperCase();
-      if (next.refBgColor && document.getElementById('ref-bg-color')) document.getElementById('ref-bg-color').value = next.refBgColor;
-      if (next.refBgColor && document.getElementById('ref-bg-color-hex')) document.getElementById('ref-bg-color-hex').value = String(next.refBgColor).toUpperCase();
-      if (next.linesPerPage != null) linesPerPage = Math.max(1, Math.min(getMaxLinesForCurrentTab(targetTab), Number(next.linesPerPage) || 1));
-      if (next.activeRatio) activeRatio = next.activeRatio === '16-9' ? '16-9' : 'full';
-      if (typeof next.ltTextTransform !== 'undefined') updateLtTextTransformValue(next.ltTextTransform, { markUser: true });
-      if (typeof next.ltRefTextTransform !== 'undefined') updateReferenceTextTransformValue('lt', next.ltRefTextTransform);
-      if (next.showVersion != null && document.getElementById('show-version')) document.getElementById('show-version').checked = !!next.showVersion;
-      if (next.showVerseNos != null && document.getElementById('show-verse-nos')) document.getElementById('show-verse-nos').checked = !!next.showVerseNos;
-      if (next.shortenBibleVersions != null && document.getElementById('shorten-bible-versions')) document.getElementById('shorten-bible-versions').checked = !!next.shortenBibleVersions;
-      if (next.shortenBibleBooks != null && document.getElementById('shorten-bible-books')) document.getElementById('shorten-bible-books').checked = !!next.shortenBibleBooks;
-      autoAdjustLtHeight = next.autoAdjustLtHeight != null ? !!next.autoAdjustLtHeight : autoAdjustLtHeight;
-      if (document.getElementById('auto-adjust-lt-height')) document.getElementById('auto-adjust-lt-height').checked = autoAdjustLtHeight;
-      if (next.autoResizeFull && document.getElementById('auto-resize-full')) document.getElementById('auto-resize-full').value = next.autoResizeFull;
-      if (next.autoResizeLT && document.getElementById('auto-resize-lt')) document.getElementById('auto-resize-lt').value = next.autoResizeLT;
-      if (next.refPositionFull && document.getElementById('ref-position-full')) document.getElementById('ref-position-full').value = next.refPositionFull;
-      if (typeof renderLtPresetOptions === 'function') renderLtPresetOptions(next.ltPresetSelection || 'default', targetTab);
-      if (typeof updateLtPresetUpdateLiveState === 'function') {
-        updateLtPresetUpdateLiveState(next.ltPresetUpdatesLive !== false);
-      }
-      if (next.ltWidthPct != null && document.getElementById('lt-width-pct')) document.getElementById('lt-width-pct').value = next.ltWidthPct;
-      if (next.ltWidthPct != null && document.getElementById('lt-width-pct-value')) document.getElementById('lt-width-pct-value').textContent = `${next.ltWidthPct}%`;
-      if (next.ltScalePct != null && document.getElementById('lt-scale-pct')) document.getElementById('lt-scale-pct').value = next.ltScalePct;
-      if (next.ltScalePct != null && document.getElementById('lt-scale-pct-value')) document.getElementById('lt-scale-pct-value').textContent = `${next.ltScalePct}%`;
-      if (next.ltOffsetX != null && document.getElementById('lt-offset-x')) document.getElementById('lt-offset-x').value = next.ltOffsetX;
-      if (next.ltOffsetY != null && document.getElementById('lt-offset-y')) document.getElementById('lt-offset-y').value = next.ltOffsetY;
-      if (next.ltBorderRadius != null && document.getElementById('lt-border-radius')) document.getElementById('lt-border-radius').value = next.ltBorderRadius;
-      if (next.ltBorderRadius != null && document.getElementById('lt-border-radius-value')) document.getElementById('lt-border-radius-value').textContent = `${next.ltBorderRadius}px`;
-      if (next.bgType && document.getElementById('bg-type')) document.getElementById('bg-type').value = next.bgType;
-      if (next.bgImageSource && document.getElementById('bg-image-source')) document.getElementById('bg-image-source').value = next.bgImageSource;
-      if (Object.prototype.hasOwnProperty.call(next, 'bgImageUrl') && document.getElementById('bg-image-url')) document.getElementById('bg-image-url').value = next.bgImageUrl || '';
-      if (Object.prototype.hasOwnProperty.call(next, 'bgUploadDataUrl')) bgUploadDataUrl = next.bgUploadDataUrl || null;
-      if (next.bgVideoSource && document.getElementById('bg-video-source')) document.getElementById('bg-video-source').value = next.bgVideoSource;
-      if (Object.prototype.hasOwnProperty.call(next, 'bgVideoUrl') && document.getElementById('bg-video-url')) document.getElementById('bg-video-url').value = next.bgVideoUrl || '';
-      if (Object.prototype.hasOwnProperty.call(next, 'bgVideoUploadDataUrl')) bgVideoUploadDataUrl = next.bgVideoUploadDataUrl || null;
-      if (next.bgVideoLoop != null && document.getElementById('bg-video-loop')) document.getElementById('bg-video-loop').checked = !!next.bgVideoLoop;
-      if (next.bgVideoSpeed != null && document.getElementById('bg-video-speed')) document.getElementById('bg-video-speed').value = next.bgVideoSpeed;
-      if (next.bgColor && document.getElementById('bg-color-quick')) document.getElementById('bg-color-quick').value = next.bgColor;
-      if (next.bgGradientShadow && document.getElementById('bg-color-shadow')) {
-        bgGradientShadow = next.bgGradientShadow;
-        document.getElementById('bg-color-shadow').value = next.bgGradientShadow;
-      }
-      if (next.bgGradientHighlight && document.getElementById('bg-color-highlight')) {
-        bgGradientHighlight = next.bgGradientHighlight;
-        document.getElementById('bg-color-highlight').value = next.bgGradientHighlight;
-      }
-      if (typeof next.bgMode !== 'undefined' && typeof setBgMode === 'function') {
-        setBgMode(next.bgMode, { silent: true });
-      } else if (typeof updateBgModeUi === 'function') {
-        updateBgModeUi();
-      }
-      if (next.bgBlur != null && document.getElementById('bg-blur')) document.getElementById('bg-blur').value = next.bgBlur;
-      if (next.bgEdgeFix != null && document.getElementById('bg-edge-fix')) document.getElementById('bg-edge-fix').value = next.bgEdgeFix ? 'on' : 'off';
-      if (next.bgOpacityFull != null) bgOpacityFull = Math.max(0, Math.min(100, Number(next.bgOpacityFull) || 0));
-      if (next.bgOpacityLT != null) bgOpacityLT = Math.max(0, Math.min(100, Number(next.bgOpacityLT) || 0));
-      if (next.bgY != null && document.getElementById('bg-y')) document.getElementById('bg-y').value = next.bgY;
-      if (next.bgToggle != null && document.getElementById('bg-toggle')) document.getElementById('bg-toggle').checked = !!next.bgToggle;
-      if (next.animateBgTransitions != null && document.getElementById('animate-bg-transitions')) document.getElementById('animate-bg-transitions').checked = !!next.animateBgTransitions;
-      if (next.bgGradientAngle != null && document.getElementById('bg-gradient-angle')) document.getElementById('bg-gradient-angle').value = next.bgGradientAngle;
-      if (document.getElementById('bg-upload-hint')) {
-        document.getElementById('bg-upload-hint').innerText = bgUploadDataUrl ? t('settings_image_selected') : t('settings_no_image_selected');
-      }
-      if (document.getElementById('bg-video-upload-hint')) {
-        document.getElementById('bg-video-upload-hint').innerText = bgVideoUploadDataUrl ? t('settings_video_selected') : t('settings_no_video_selected');
-      }
-      if (typeof handleBgTypeChange === 'function') handleBgTypeChange();
-      if (typeof syncBgOpacitySlider === 'function') syncBgOpacitySlider();
-      fullRefHAlign = next.hAlignFullRef || fullRefHAlign;
-      fullHAlign = next.hAlignFull || fullHAlign;
-      fullVAlign = next.vAlignFull || fullVAlign;
-      ltHAlignSongs = next.hAlignLTSongs || ltHAlignSongs;
-      ltVAlignSongs = next.vAlignLTSongs || ltVAlignSongs;
-      ltAnchorMode = next.ltAnchorMode === 'top' ? 'top' : 'bottom';
-      ltHAlignBible = next.hAlignLTBible || ltHAlignBible;
-      ltVAlignBible = next.vAlignLTBible || ltVAlignBible;
-      ltHAlignBibleVerse = next.hAlignLTBibleVerse || ltHAlignBibleVerse;
-      if (next.refBgEnabled != null) setRefBgEnabled(!!next.refBgEnabled, { silent: true });
-      if (next.referenceShadowEnabled != null) setReferenceShadowEnabled(!!next.referenceShadowEnabled, { silent: true });
-      if (next.verseShadowEnabled != null) setVerseShadowEnabled(!!next.verseShadowEnabled, { silent: true });
-      if (next.referenceTextCapitalized != null) setReferenceCapitalized(!!next.referenceTextCapitalized, { silent: true });
-      if (next.dualVersionModeEnabled != null) setDualVersionModeEnabled(!!next.dualVersionModeEnabled, { silent: true });
-      if (Object.prototype.hasOwnProperty.call(next, 'dualVersionSecondaryId')) setDualVersionSecondaryId(next.dualVersionSecondaryId || null, { silent: true });
-      setLtFontInputValue(getEffectiveLtFont());
-      updateFullAlignButtons();
-      updateLtAlignButtons();
-      if (typeof refreshSliderPaint === 'function') {
-        refreshSliderPaint([
-          'line-height-full',
-          'line-height-lt',
-          'pad-lr-full',
-          'pad-lr-lt',
-          'lt-width-pct',
-          'lt-scale-pct',
-          'lt-border-radius',
-          'bg-blur',
-          'bg-opacity-full',
-          'bg-opacity-lt',
-          'bg-y',
-          'bg-gradient-angle',
-          'bg-video-speed'
-        ]);
-      }
-      if (typeof syncLtPresetSelectionToCurrentValues === 'function') {
-        syncLtPresetSelectionToCurrentValues(targetTab);
-      }
-      document.querySelectorAll('#line-picker .seg-btn').forEach((b) => b.classList.toggle('active', b.id === 'line-' + linesPerPage));
-      document.getElementById('ratio-full')?.classList.toggle('active', activeRatio === 'full');
-      document.getElementById('ratio-lt')?.classList.toggle('active', activeRatio === '16-9');
-      document.getElementById('ratio-custom')?.classList.toggle('active', false);
-      updateLinePickerAvailability();
-      updateCustomModeAvailability();
-      updateTextEditorModeAvailability();
-      if (opts.triggerChange && typeof onAnyControlChange === 'function') onAnyControlChange();
-    }
-
-    function applyProjectionSettingsProfileForTab(tab, opts = {}) {
-      if (!SETTINGS_TARGET_TABS.includes(tab)) return false;
-      applyProjectionSettingsSnapshot(getProjectionSettingsSnapshotForTab(tab), { ...opts, tab });
-      return true;
-    }
-
-    function setMediaSettingsTargetActive(active) {
-      const next = !!active;
-      if (next === mediaSettingsTargetActive) return;
-      if (next) saveProjectionSettingsProfileForTab(getEffectiveSettingsTargetTab());
-      mediaSettingsTargetActive = next;
-      updateSettingsTargetControl();
-    }
-
-    function setSettingsTargetTab(target, opts = {}) {
-      saveProjectionSettingsProfileForTab(getEffectiveSettingsTargetTab());
-      mediaSettingsTargetActive = false;
-      settingsTargetTab = normalizeSettingsTargetTab(target);
-      updateSettingsTargetControl();
-      applyProjectionSettingsProfileForTab(getEffectiveSettingsTargetTab(), { triggerChange: !!opts.triggerChange });
-      const isLockedInactiveTarget = settingsTargetTab !== 'follow' && getEffectiveSettingsTargetTab() !== sidebarTab;
-      if (isLockedInactiveTarget) {
-        applyProjectionRuntimeSnapshot(getProjectionSettingsSnapshotForTab(sidebarTab));
-      }
-      if (!opts.silent) saveToStorageDebounced();
-    }
-
-    function handleSettingsTargetChange(target) {
-      if (target === 'media') {
-        setMediaSettingsTargetActive(true);
-        return;
-      }
-      setSettingsTargetTab(target || 'bible');
-    }
-
-    function getSetlistSettingsSnapshot() {
-      const autoGoLiveToggle = document.getElementById('setlist-auto-go-live');
-      const advancePreviewToggle = document.getElementById('setlist-advance-preview');
-      return {
-        autoGoLiveOnSelect: autoGoLiveToggle ? !!autoGoLiveToggle.checked : !!setlistSettings.autoGoLiveOnSelect,
-        advancePreviewAfterLive: advancePreviewToggle ? !!advancePreviewToggle.checked : !!setlistSettings.advancePreviewAfterLive
-      };
-    }
-
-    function applySetlistSettingsSnapshot(raw) {
-      const source = (raw && typeof raw === 'object') ? raw : {};
-      setlistSettings = {
-        autoGoLiveOnSelect: source.autoGoLiveOnSelect === true,
-        advancePreviewAfterLive: source.advancePreviewAfterLive !== false
-      };
-      const autoGoLiveToggle = document.getElementById('setlist-auto-go-live');
-      if (autoGoLiveToggle) autoGoLiveToggle.checked = !!setlistSettings.autoGoLiveOnSelect;
-      const advancePreviewToggle = document.getElementById('setlist-advance-preview');
-      if (advancePreviewToggle) advancePreviewToggle.checked = !!setlistSettings.advancePreviewAfterLive;
-      return { ...setlistSettings };
-    }
-
-
-    // ===== STATE =====
-    function getUiSnapshot() {
-      if (isFocusedWorkspaceMode()) {
-        saveFocusedWorkspaceControlsForTab(sidebarTab);
-      }
-      saveProjectionSettingsProfileForTab(getEffectiveSettingsTargetTab());
-      return {
-        language: currentLanguage,
-        fontFamily: document.getElementById('font-family').value,
-        fontWeight: document.getElementById('font-weight').value,
-        fontSizeFull: document.getElementById('font-size-val').value,
-        ltFontSongs, ltFontBible, ltFontCustom,
-        refFontSize: document.getElementById('ref-font-size-val').value,
-        refBgColor: document.getElementById('ref-bg-color').value,
-        autoAdjustLtHeight: document.getElementById('auto-adjust-lt-height').checked,
-        ltStyle,
-        songTransitionType: document.getElementById('song-transition-type').value,
-        songTransitionDuration: document.getElementById('song-transition-duration').value,
-        animateBgTransitions: document.getElementById('animate-bg-transitions').checked,
-        ltStyles,
-        customFonts,
-        bgType: document.getElementById('bg-type').value,
-        bgImageSource: document.getElementById('bg-image-source').value,
-        bgImageUrl: document.getElementById('bg-image-url').value,
-        bgUploadDataUrl,
-        bgVideoSource: document.getElementById('bg-video-source').value,
-        bgVideoUrl: document.getElementById('bg-video-url').value,
-        bgVideoUploadDataUrl,
-        bgVideoLoop: document.getElementById('bg-video-loop').checked,
-        bgVideoSpeed: document.getElementById('bg-video-speed').value,
-        bgMode,
-        bgColor: document.getElementById('bg-color-quick').value,
-        bgGradientShadow: document.getElementById('bg-color-shadow').value,
-        bgGradientHighlight: document.getElementById('bg-color-highlight').value,
-        bgBlur: document.getElementById('bg-blur').value,
-        bgEdgeFix: document.getElementById('bg-edge-fix').value,
-        bgOpacity: getActiveBgOpacityValue(),
-        bgOpacityFull,
-        bgOpacityLT,
-        bgY: document.getElementById('bg-y').value,
-        bgGradientAngle: document.getElementById('bg-gradient-angle')?.value || 135,
-        textX: document.getElementById('text-x')?.value ?? 0,
-        textY: document.getElementById('text-y')?.value ?? 860,
-        padLR: document.getElementById('pad-lr-lt')?.value ?? 5,
-        padLRFull: document.getElementById('pad-lr-full')?.value ?? 5,
-        padLRLT: document.getElementById('pad-lr-lt')?.value ?? 5,
-        padB: document.getElementById('pad-b')?.value ?? 0,
-        fullTextTransform: document.getElementById('full-text-transform')?.value || fullTextTransform,
-        ltTextTransform: document.getElementById('lt-text-transform')?.value || 'uppercase',
-        showVersion: document.getElementById('show-version').checked,
-        shortenBibleVersions: document.getElementById('shorten-bible-versions')?.checked,
-        shortenBibleBooks: document.getElementById('shorten-bible-books')?.checked,
-        showSongSolfaNotes: document.getElementById('show-song-solfa-notes')?.checked !== false,
-        showSongCategoryName: document.getElementById('show-song-category-name')?.checked !== false,
-        displaySongSections: document.getElementById('display-song-sections')?.checked === true,
-        songBilingualEnabled: document.getElementById('song-bilingual-enabled')?.checked === true,
-        songDisplayMode: document.getElementById('song-display-mode')?.value || DEFAULT_SONG_BILINGUAL_SETTINGS.displayMode,
-        songTranslationMode: document.getElementById('song-translation-mode')?.value || DEFAULT_SONG_BILINGUAL_SETTINGS.translationMode,
-        songAutoTranslateOnImport: document.getElementById('song-auto-translate-import')?.checked !== false,
-        songAutoTranslateOnOpen: document.getElementById('song-auto-translate-open')?.checked !== false,
-        songTargetLanguage: (document.getElementById('song-translation-language')?.value || DEFAULT_SONG_BILINGUAL_SETTINGS.targetLanguage).trim(),
-        songSourceLanguage: (document.getElementById('song-translation-source-language')?.value || DEFAULT_SONG_BILINGUAL_SETTINGS.sourceLanguage).trim(),
-        songSecondaryFontScale: document.getElementById('song-secondary-font-scale')?.value || DEFAULT_SONG_BILINGUAL_SETTINGS.secondaryFontScale,
-        songCacheTranslationsLocally: document.getElementById('song-cache-translations')?.checked !== false,
-        songFreeTranslationApiUrl: (document.getElementById('song-free-translation-api-url')?.value || DEFAULT_SONG_BILINGUAL_SETTINGS.freeTranslationApiUrl).trim(),
-        songTranslationApiUrl: (document.getElementById('song-translation-api-url')?.value || '').trim(),
-        songTranslationApiKey: document.getElementById('song-translation-api-key')?.value || '',
-        showVerseNos: document.getElementById('show-verse-nos').checked,
-        versionSwitchUpdatesLive: document.getElementById('version-switch-updates-live').checked,
-        textColor: document.getElementById('text-color').value,
-        refColor: document.getElementById('ref-color').value,
-        linesPerPage,
-        activeRatio,
-        lineHeightFull: document.getElementById('line-height-full').value,
-        lineHeightLT: document.getElementById('line-height-lt').value,
-        ltWidthPct: document.getElementById('lt-width-pct')?.value || 100,
-        ltScalePct: document.getElementById('lt-scale-pct')?.value || 100,
-        ltOffsetY: document.getElementById('lt-offset-y')?.value || 0,
-        ltOffsetX: document.getElementById('lt-offset-x')?.value || 0,
-        ltBorderRadius: document.getElementById('lt-border-radius')?.value || 0,
-        bgToggle: document.getElementById('bg-toggle').checked,
-        hAlignFullRef: fullRefHAlign,
-        hAlignFull: fullHAlign,
-        vAlignFull: fullVAlign,
-        hAlignLTSongs: ltHAlignSongs,
-        vAlignLTSongs: ltVAlignSongs,
-        ltAnchorMode,
-        hAlignLTBible: ltHAlignBible,
-        vAlignLTBible: ltVAlignBible,
-        hAlignLTBibleVerse: ltHAlignBibleVerse,
-        autoResizeFull: document.getElementById('auto-resize-full').value,
-        autoResizeLT: document.getElementById('auto-resize-lt')?.value,
-        refPositionFull: document.getElementById('ref-position-full')?.value,
-        remoteShowEnabled: document.getElementById('remote-show-toggle')?.checked,
-        remoteShowUseHostname: document.getElementById('remote-show-use-hostname')?.checked,
-        remoteShowHost: document.getElementById('remote-show-host')?.value,
-        remoteShowPort: document.getElementById('remote-show-port')?.value,
-        remoteShowRelayHost: document.getElementById('remote-show-relay-host')?.value,
-        remoteShowRelayPort: document.getElementById('remote-show-relay-port')?.value,
-        remoteShowPairCode: document.getElementById('remote-show-pair-code')?.value,
-        feedbackApiUrl: normalizeFeedbackApiUrl(appState?.settings?.feedbackApiUrl),
-        hostMode: getHostMode(),
-        vmix: getVmixSettings(),
-        theme: document.getElementById('theme-select')?.value || 'skyline',
-        sidebarLayout: document.getElementById('sidebar-layout-select')?.value || sidebarLayoutMode || 'layout2',
-        workspaceLayoutMode: document.getElementById('workspace-layout-mode-select')?.value || workspaceLayoutMode || 'focused',
-        focusedWorkspaceControls: ensureFocusedWorkspaceControlsState(),
-        projectionSettingsProfiles: ensureProjectionSettingsProfiles(),
-        settingsTargetTab: normalizeSettingsTargetTab(settingsTargetTab),
-        setlistSettings: getSetlistSettingsSnapshot(),
-        ltModeUserPresets: Array.isArray(ltModeUserPresets)
-          ? ltModeUserPresets.map((preset) => ({
-              ...preset,
-              values: preset && preset.values ? { ...preset.values } : null
-            }))
-          : []
-      };
-    }
+// ===== STATE =====
+function getUiSnapshot() {
+  if (isFocusedWorkspaceMode()) {
+    saveFocusedWorkspaceControlsForTab(sidebarTab);
+  }
+  saveProjectionSettingsProfileForTab(getEffectiveSettingsTargetTab());
+  return {
+    language: currentLanguage,
+    fontFamily: document.getElementById("font-family").value,
+    fontWeight: document.getElementById("font-weight").value,
+    fontSizeFull: document.getElementById("font-size-val").value,
+    ltFontSongs,
+    ltFontBible,
+    ltFontCustom,
+    refFontSize: document.getElementById("ref-font-size-val").value,
+    refBgColor: document.getElementById("ref-bg-color").value,
+    autoAdjustLtHeight: document.getElementById("auto-adjust-lt-height")
+      .checked,
+    ltStyle,
+    songTransitionType: document.getElementById("song-transition-type").value,
+    songTransitionDuration: document.getElementById("song-transition-duration")
+      .value,
+    animateBgTransitions: document.getElementById("animate-bg-transitions")
+      .checked,
+    ltStyles,
+    customFonts,
+    bgType: document.getElementById("bg-type").value,
+    bgImageSource: document.getElementById("bg-image-source").value,
+    bgImageUrl: document.getElementById("bg-image-url").value,
+    bgUploadDataUrl,
+    bgVideoSource: document.getElementById("bg-video-source").value,
+    bgVideoUrl: document.getElementById("bg-video-url").value,
+    bgVideoUploadDataUrl,
+    bgVideoLoop: document.getElementById("bg-video-loop").checked,
+    bgVideoSpeed: document.getElementById("bg-video-speed").value,
+    bgMode,
+    bgColor: document.getElementById("bg-color-quick").value,
+    bgGradientShadow: document.getElementById("bg-color-shadow").value,
+    bgGradientHighlight: document.getElementById("bg-color-highlight").value,
+    bgBlur: document.getElementById("bg-blur").value,
+    bgEdgeFix: document.getElementById("bg-edge-fix").value,
+    bgOpacity: getActiveBgOpacityValue(),
+    bgOpacityFull,
+    bgOpacityLT,
+    bgY: document.getElementById("bg-y").value,
+    bgGradientAngle: document.getElementById("bg-gradient-angle")?.value || 135,
+    textX: document.getElementById("text-x")?.value ?? 0,
+    textY: document.getElementById("text-y")?.value ?? 860,
+    padLR: document.getElementById("pad-lr-lt")?.value ?? 5,
+    padLRFull: document.getElementById("pad-lr-full")?.value ?? 5,
+    padLRLT: document.getElementById("pad-lr-lt")?.value ?? 5,
+    padB: document.getElementById("pad-b")?.value ?? 0,
+    fullTextTransform:
+      document.getElementById("full-text-transform")?.value ||
+      fullTextTransform,
+    ltTextTransform:
+      document.getElementById("lt-text-transform")?.value || "uppercase",
+    showVersion: document.getElementById("show-version").checked,
+    shortenBibleVersions: document.getElementById("shorten-bible-versions")
+      ?.checked,
+    shortenBibleBooks: document.getElementById("shorten-bible-books")?.checked,
+    showSongSolfaNotes:
+      document.getElementById("show-song-solfa-notes")?.checked !== false,
+    showSongCategoryName:
+      document.getElementById("show-song-category-name")?.checked !== false,
+    displaySongSections:
+      document.getElementById("display-song-sections")?.checked === true,
+    songBilingualEnabled:
+      document.getElementById("song-bilingual-enabled")?.checked === true,
+    songDisplayMode:
+      document.getElementById("song-display-mode")?.value ||
+      DEFAULT_SONG_BILINGUAL_SETTINGS.displayMode,
+    songTranslationMode:
+      document.getElementById("song-translation-mode")?.value ||
+      DEFAULT_SONG_BILINGUAL_SETTINGS.translationMode,
+    songAutoTranslateOnImport:
+      document.getElementById("song-auto-translate-import")?.checked !== false,
+    songAutoTranslateOnOpen:
+      document.getElementById("song-auto-translate-open")?.checked !== false,
+    songTargetLanguage: (
+      document.getElementById("song-translation-language")?.value ||
+      DEFAULT_SONG_BILINGUAL_SETTINGS.targetLanguage
+    ).trim(),
+    songSourceLanguage: (
+      document.getElementById("song-translation-source-language")?.value ||
+      DEFAULT_SONG_BILINGUAL_SETTINGS.sourceLanguage
+    ).trim(),
+    songSecondaryFontScale:
+      document.getElementById("song-secondary-font-scale")?.value ||
+      DEFAULT_SONG_BILINGUAL_SETTINGS.secondaryFontScale,
+    songCacheTranslationsLocally:
+      document.getElementById("song-cache-translations")?.checked !== false,
+    songFreeTranslationApiUrl: (
+      document.getElementById("song-free-translation-api-url")?.value ||
+      DEFAULT_SONG_BILINGUAL_SETTINGS.freeTranslationApiUrl
+    ).trim(),
+    songTranslationApiUrl: (
+      document.getElementById("song-translation-api-url")?.value || ""
+    ).trim(),
+    songTranslationApiKey:
+      document.getElementById("song-translation-api-key")?.value || "",
+    showVerseNos: document.getElementById("show-verse-nos").checked,
+    versionSwitchUpdatesLive: document.getElementById(
+      "version-switch-updates-live",
+    ).checked,
+    textColor: document.getElementById("text-color").value,
+    refColor: document.getElementById("ref-color").value,
+    linesPerPage,
+    activeRatio,
+    lineHeightFull: document.getElementById("line-height-full").value,
+    lineHeightLT: document.getElementById("line-height-lt").value,
+    ltWidthPct: document.getElementById("lt-width-pct")?.value || 100,
+    ltScalePct: document.getElementById("lt-scale-pct")?.value || 100,
+    ltOffsetY: document.getElementById("lt-offset-y")?.value || 0,
+    ltOffsetX: document.getElementById("lt-offset-x")?.value || 0,
+    ltBorderRadius: document.getElementById("lt-border-radius")?.value || 0,
+    bgToggle: document.getElementById("bg-toggle").checked,
+    hAlignFullRef: fullRefHAlign,
+    hAlignFull: fullHAlign,
+    vAlignFull: fullVAlign,
+    hAlignLTSongs: ltHAlignSongs,
+    vAlignLTSongs: ltVAlignSongs,
+    ltAnchorMode,
+    hAlignLTBible: ltHAlignBible,
+    vAlignLTBible: ltVAlignBible,
+    hAlignLTBibleVerse: ltHAlignBibleVerse,
+    autoResizeFull: document.getElementById("auto-resize-full").value,
+    autoResizeLT: document.getElementById("auto-resize-lt")?.value,
+    refPositionFull: document.getElementById("ref-position-full")?.value,
+    remoteShowEnabled: document.getElementById("remote-show-toggle")?.checked,
+    remoteShowUseHostname: document.getElementById("remote-show-use-hostname")
+      ?.checked,
+    remoteShowHost: document.getElementById("remote-show-host")?.value,
+    remoteShowPort: document.getElementById("remote-show-port")?.value,
+    remoteShowRelayHost: document.getElementById("remote-show-relay-host")
+      ?.value,
+    remoteShowRelayPort: document.getElementById("remote-show-relay-port")
+      ?.value,
+    remoteShowPairCode: document.getElementById("remote-show-pair-code")?.value,
+    feedbackApiUrl: normalizeFeedbackApiUrl(appState?.settings?.feedbackApiUrl),
+    hostMode: getHostMode(),
+    vmix: getVmixSettings(),
+    theme: document.getElementById("theme-select")?.value || "skyline",
+    sidebarLayout:
+      document.getElementById("sidebar-layout-select")?.value ||
+      sidebarLayoutMode ||
+      "layout2",
+    workspaceLayoutMode:
+      document.getElementById("workspace-layout-mode-select")?.value ||
+      workspaceLayoutMode ||
+      "focused",
+    focusedWorkspaceControls: ensureFocusedWorkspaceControlsState(),
+    projectionSettingsProfiles: ensureProjectionSettingsProfiles(),
+    settingsTargetTab: normalizeSettingsTargetTab(settingsTargetTab),
+    setlistSettings: getSetlistSettingsSnapshot(),
+    ltModeUserPresets: Array.isArray(ltModeUserPresets)
+      ? ltModeUserPresets.map((preset) => ({
+          ...preset,
+          values: preset && preset.values ? { ...preset.values } : null,
+        }))
+      : [],
+  };
+}


### PR DESCRIPTION
## Fix cross-language Bible reference search

### Problem

Bible reference search was dependent on the language/name of the currently selected Bible.

For example, when a Yoruba Bible was selected, searching for:

`John 3:16`

could fail because the selected Bible uses the localized book name:

`Jòhánù 3:16`

Likewise, with an English Bible selected, searching for the Yoruba reference could fail.

### Changes

This PR makes Bible reference resolution language-independent by:

* Resolving Bible book names to their canonical 1–66 book numbers.
* Using the existing multilingual `BIBLE_BOOK_TRANSLATIONS` data for localized book names.
* Supporting canonical English book names and common abbreviations.
* Storing the canonical book number when parsing imported Bible XML.
* Matching references using the canonical book number instead of relying only on the currently displayed book name.
* Updating reference parsing so the `Book Chapter:Verse` format works regardless of the language of the selected Bible.
* Updating book validation used when entering a colon/verse reference.

### Examples

The following now resolve correctly regardless of the selected Bible language:

* `John 3:16`
* `Jòhánù 3:16`
* `Genesis 1:1`
* `Jẹ́nẹ́sísì 1:1`
* `Romans 8:28`
* `Róòmù 8:28`
* `1 Cor 13:4`
* `1 Kọ́ríńtì 13:4`

The selected Bible version remains unchanged; only the reference is resolved to the corresponding canonical book.

### Testing

Tested cross-language reference searches with English and Yoruba Bible versions, including:

* Full book names
* Localized book names
* Common abbreviations
* Numbered books
* Chapter-only references
* Chapter and verse references

The displayed book name continues to use the selected Bible's own language.